### PR TITLE
Default configuration

### DIFF
--- a/Source/Applications/ApplicationConfigurationBuilder.cs
+++ b/Source/Applications/ApplicationConfigurationBuilder.cs
@@ -34,7 +34,6 @@ namespace Dolittle.Applications
             Logger.Internal.Trace($"Building application {name} with a given structure map builder");
         }
         
-
         /// <summary>
         /// Initializes a new instance of <see cref="ApplicationConfigurationBuilder"/>
         /// </summary>
@@ -56,7 +55,6 @@ namespace Dolittle.Applications
             return applicationConfigurationBuilder;
         }
 
-
         /// <inheritdoc/>
         public IApplicationConfigurationBuilder StructureMappedTo(Func<IApplicationStructureMapBuilder, IApplicationStructureMapBuilder> callback)
         {
@@ -73,5 +71,6 @@ namespace Dolittle.Applications
             var applicationStructureMap = _structureMapBuilder.Build(application);
             return (application: application, structureMap: applicationStructureMap);
         }
+
     }
 }

--- a/Source/Applications/ApplicationLocationResolver.cs
+++ b/Source/Applications/ApplicationLocationResolver.cs
@@ -17,26 +17,6 @@ namespace Dolittle.Applications
     /// </summary>
     public class ApplicationLocationResolver : IApplicationLocationResolver
     {
-        /// <summary>
-        /// The key representing a <see cref="IBoundedContext"/> as part of <see cref="IApplicationStructureMapBuilder"/>
-        /// </summary>
-        public const string BoundedContextKey = "BoundedContext";
-
-        /// <summary>
-        /// The key representing a <see cref="IModule"/> as part of <see cref="IApplicationStructureMapBuilder"/>
-        /// </summary>
-        public const string ModuleKey = "Module";
-
-        /// <summary>
-        /// The key representing a <see cref="IFeature"/> as part of <see cref="IApplicationStructureMapBuilder"/>
-        /// </summary>
-        public const string FeatureKey = "Feature";
-
-        /// <summary>
-        /// The key representing a <see cref="ISubFeature"/> as part of <see cref="IApplicationStructureMapBuilder"/>
-        /// </summary>
-        public const string SubFeatureKey = "SubFeature";
-
         readonly IApplicationStructureMap _applicationStructureMap;
         readonly IApplication _application;
 
@@ -92,10 +72,10 @@ namespace Dolittle.Applications
 
                 switch( stringSegment.Identifier )
                 {
-                    case BoundedContextKey : currentSegment = new BoundedContext(stringSegment.Values.Single()); break;
-                    case ModuleKey : currentSegment = new Module((BoundedContext)previousSegment, stringSegment.Values.Single()); break;
-                    case FeatureKey : currentSegment = new Feature(previousSegment, stringSegment.Values.Single()); break;
-                    case SubFeatureKey : 
+                    case ApplicationStructureMap.BoundedContextKey : currentSegment = new BoundedContext(stringSegment.Values.Single()); break;
+                    case ApplicationStructureMap.ModuleKey : currentSegment = new Module((BoundedContext)previousSegment, stringSegment.Values.Single()); break;
+                    case ApplicationStructureMap.FeatureKey : currentSegment = new Feature(previousSegment, stringSegment.Values.Single()); break;
+                    case ApplicationStructureMap.SubFeatureKey : 
                         foreach (var segmentString in stringSegment.Values)
                         {
                             currentSegment = new SubFeature((IFeature)previousSegment, segmentString);
@@ -106,7 +86,7 @@ namespace Dolittle.Applications
                         }
                         break;
                 }
-                if( currentSegment != null )
+                if ( currentSegment != null )
                 {
                     segments.Add(currentSegment);
                     previousSegment = currentSegment;

--- a/Source/Applications/ApplicationStructureMap.cs
+++ b/Source/Applications/ApplicationStructureMap.cs
@@ -16,8 +16,28 @@ namespace Dolittle.Applications
     /// </summary>
     public class ApplicationStructureMap : IApplicationStructureMap
     {
+        /// <summary>
+        /// The key representing a <see cref="IBoundedContext"/> as part of <see cref="IApplicationStructureMapBuilder"/>
+        /// </summary>
+        public const string BoundedContextKey = "BoundedContext";
+
+        /// <summary>
+        /// The key representing a <see cref="IModule"/> as part of <see cref="IApplicationStructureMapBuilder"/>
+        /// </summary>
+        public const string ModuleKey = "Module";
+
+        /// <summary>
+        /// The key representing a <see cref="IFeature"/> as part of <see cref="IApplicationStructureMapBuilder"/>
+        /// </summary>
+        public const string FeatureKey = "Feature";
+
+        /// <summary>
+        /// The key representing a <see cref="ISubFeature"/> as part of <see cref="IApplicationStructureMapBuilder"/>
+        /// </summary>
+        public const string SubFeatureKey = "SubFeature";
+        
         readonly IApplication _application;
-                readonly IEnumerable<IStringFormat> _formats;
+        readonly IEnumerable<IStringFormat> _formats;
 
         /// <summary>
         /// Initializes a new instance of <see cref="ApplicationStructureMap"/>

--- a/Source/Applications/ApplicationStructureMapBuilder.cs
+++ b/Source/Applications/ApplicationStructureMapBuilder.cs
@@ -16,7 +16,6 @@ namespace Dolittle.Applications
     {
         readonly IEnumerable<IStringFormat> _structureFormats;
 
-
         /// <summary>
         /// Initializes a new instance of <see cref="ApplicationStructureMapBuilder"/>
         /// </summary>

--- a/Source/Configuration/Config.cs
+++ b/Source/Configuration/Config.cs
@@ -13,7 +13,7 @@ namespace Dolittle.Configuration
     public class Config
     {
         /// <summary>
-        /// Gets the <see cref="Application"/> of the <see cref="IApplication"/>
+        /// Gets the <see cref="ApplicationName"/> of the <see cref="IApplication"/>
         /// </summary>
         public ApplicationName Application { get; set; } = ApplicationName.NotSet;
 

--- a/Source/Configuration/Config.cs
+++ b/Source/Configuration/Config.cs
@@ -13,14 +13,14 @@ namespace Dolittle.Configuration
     public class Config
     {
         /// <summary>
-        /// Gets the <see cref="ApplicationName"/> of the <see cref="IApplication"/>
+        /// Gets the <see cref="Application"/> of the <see cref="IApplication"/>
         /// </summary>
-        public ApplicationName ApplicationName { get; set; } = ApplicationName.NotSet;
+        public ApplicationName Application { get; set; } = ApplicationName.NotSet;
 
         /// <summary>
-        /// Gets the name of the <see cref="BoundedContext"/> of the running host
+        /// Gets the name of the <see cref="Applications.BoundedContext"/> of the running host
         /// </summary>
-        public BoundedContextName BoundedContextName { get; set; } = BoundedContextName.NotSet;
+        public BoundedContextName BoundedContext { get; set; } = BoundedContextName.NotSet;
 
         /// <summary>
         /// The name of the Domain area

--- a/Source/Configuration/Config.cs
+++ b/Source/Configuration/Config.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using Dolittle.Applications;
+using Dolittle.Strings;
 
 namespace Dolittle.Configuration
 {
@@ -14,11 +15,35 @@ namespace Dolittle.Configuration
         /// <summary>
         /// Gets the <see cref="ApplicationName"/> of the <see cref="IApplication"/>
         /// </summary>
-        public ApplicationName Application { get; set; } = ApplicationName.NotSet;
+        public ApplicationName ApplicationName { get; set; } = ApplicationName.NotSet;
 
         /// <summary>
         /// Gets the name of the <see cref="BoundedContext"/> of the running host
         /// </summary>
-        public BoundedContextName BoundedContext { get; set; } = BoundedContextName.NotSet;
+        public BoundedContextName BoundedContextName { get; set; } = BoundedContextName.NotSet;
+
+        /// <summary>
+        /// The name of the Domain area
+        /// </summary>
+        /// <value></value>        
+        public string DomainAreaName {get; set; } = "Domain";
+
+        /// <summary>
+        /// The name of the Events area
+        /// </summary>
+        /// <value></value>
+        public string EventsAreaName {get; set; } = "Events";
+
+        /// <summary>
+        /// The name of the Read area
+        /// </summary>
+        /// <value></value>
+        public string ReadAreaName {get; set; } = "Read";
+
+        /// <summary>
+        /// The name of the Frontend area
+        /// </summary>
+        /// <value></value>
+        public string FrontendAreaName {get; set; } = "Web";
     }
 }

--- a/Source/Configuration/Configuration.csproj
+++ b/Source/Configuration/Configuration.csproj
@@ -10,5 +10,8 @@
         <PackageReference Include="Dolittle.Concepts.Serialization.Json" Version="2.0.0-*" />
         <PackageReference Include="Dolittle.Serialization.Json" Version="2.0.0-*" />
     </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Applications\Applications.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/Source/Configuration/ConfigurationNotSpecified.cs
+++ b/Source/Configuration/ConfigurationNotSpecified.cs
@@ -13,8 +13,8 @@ namespace Dolittle.Configuration
         /// </summary>
         public ConfigurationNotSpecified() 
             : base($"No configuration details has been specified.\n"+
-             $"To get a default configuration for an {typeof(IApplication).AssemblyQualifiedName} you need to have specified an ApplicationName and BoundedContextName in a {JsonFile.DolittleJsonFileName} " +
-             $"or provide the {typeof(DefaultApplication).AssemblyQualifiedName} with a {typeof(Config).AssemblyQualifiedName}")
+             $"To get a default configuration for an {typeof(IApplication).AssemblyQualifiedName} you need to have specified names for Application and BoundedContext in a {JsonFile.DolittleJsonFileName} config file " +
+             $"or provide the default configuration with an instance of {typeof(Config).AssemblyQualifiedName}")
         {
 
         }

--- a/Source/Configuration/ConfigurationNotSpecified.cs
+++ b/Source/Configuration/ConfigurationNotSpecified.cs
@@ -1,0 +1,22 @@
+using System;
+using Dolittle.Applications;
+
+namespace Dolittle.Configuration
+{
+    /// <summary>
+    /// The exception that gets thrown when the <see cref="DefaultApplication"/> is requested, but no configuration details are given.
+    /// </summary>
+    public class ConfigurationNotSpecified : Exception
+    {
+        /// <summary>
+        /// Instantiates an <see cref="ConfigurationNotSpecified"/> exception.
+        /// </summary>
+        public ConfigurationNotSpecified() 
+            : base($"No configuration details has been specified.\n"+
+             $"To get a default configuration for an {typeof(IApplication).AssemblyQualifiedName} you need to have specified an ApplicationName and BoundedContextName in a {JsonFile.DolittleJsonFileName} " +
+             $"or provide the {typeof(DefaultApplication).AssemblyQualifiedName} with a {typeof(Config).AssemblyQualifiedName}")
+        {
+
+        }
+    }
+}

--- a/Source/Configuration/DefaultApplication.cs
+++ b/Source/Configuration/DefaultApplication.cs
@@ -45,11 +45,11 @@ namespace Dolittle.Configuration
         DefaultApplication(Config config)
         {
             ThrowIfNoConfigurationDetails(config);
-            
-            Config = config;
-            BoundedContext = new BoundedContext(config.BoundedContextName);
 
-            ApplicationBuilder = new ApplicationBuilder(config.ApplicationName)
+            Config = config;
+            BoundedContext = new BoundedContext(config.BoundedContext);
+
+            ApplicationBuilder = new ApplicationBuilder(config.Application)
                 .PrefixLocationsWith(BoundedContext)
                 .WithStructureStartingWith<BoundedContext>(bc => bc.Required
                     .WithChild<Module>(m => m
@@ -66,8 +66,8 @@ namespace Dolittle.Configuration
 
         void ThrowIfNoConfigurationDetails(Config config)
         {
-            if (config.ApplicationName.Equals(ApplicationName.NotSet) 
-                || config.BoundedContextName.Equals(BoundedContextName.NotSet))
+            if (config.Application.Equals(ApplicationName.NotSet) 
+                || config.BoundedContext.Equals(BoundedContextName.NotSet))
             {
                 throw new ConfigurationNotSpecified();
             }

--- a/Source/Configuration/DefaultApplication.cs
+++ b/Source/Configuration/DefaultApplication.cs
@@ -7,7 +7,21 @@ namespace Dolittle.Configuration
     /// </summary>
     public class DefaultApplication
     {
-
+        /// <summary>
+        /// Gets the default <see cref="IApplicationBuilder"/> for a given <see cref="Config"/> with <see cref="BoundedContext"/> as prefix
+        /// </summary>
+        /// <param name="config">The configuration</param>
+        /// <param name="boundedContext">The <see cref="BoundedContext"/> to use as location prefix</param>
+        /// <returns></returns>
+        public static IApplicationBuilder GetDefaultApplicationBuilderForConfig(Config config, BoundedContext boundedContext)
+        {
+            return new ApplicationBuilder(config.Application)
+                .PrefixLocationsWith(boundedContext)
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required
+                    .WithChild<Module>(m => m
+                        .WithChild<Feature>(f => f
+                            .WithChild<SubFeature>(sf => sf.Recursive))));
+        }
         /// <summary>
         /// Gets the <see cref="DefaultApplication"/> based on the configuration details specified in the dolittle configuration json file.
         /// </summary>
@@ -40,7 +54,7 @@ namespace Dolittle.Configuration
         /// <summary>
         /// The default <see cref="IBoundedContext"/> that's generated.
         /// </summary>
-        public IBoundedContext BoundedContext {get; }
+        public BoundedContext BoundedContext {get; }
 
         DefaultApplication(Config config)
         {
@@ -49,12 +63,7 @@ namespace Dolittle.Configuration
             Config = config;
             BoundedContext = new BoundedContext(config.BoundedContext);
 
-            ApplicationBuilder = new ApplicationBuilder(config.Application)
-                .PrefixLocationsWith(BoundedContext)
-                .WithStructureStartingWith<BoundedContext>(bc => bc.Required
-                    .WithChild<Module>(m => m
-                        .WithChild<Feature>(f => f
-                            .WithChild<SubFeature>(sf => sf.Recursive))));
+            ApplicationBuilder = GetDefaultApplicationBuilderForConfig(config, BoundedContext);
 
         }
 

--- a/Source/Configuration/DefaultApplication.cs
+++ b/Source/Configuration/DefaultApplication.cs
@@ -1,0 +1,76 @@
+using Dolittle.Applications;
+
+namespace Dolittle.Configuration
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DefaultApplication
+    {
+
+        /// <summary>
+        /// Gets the <see cref="DefaultApplication"/> based on the configuration details specified in the dolittle configuration json file.
+        /// </summary>
+        public static DefaultApplication GetDefaultApplication()
+        {
+            return new DefaultApplication(JsonFile.GetConfig());    
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DefaultApplication"/> based on the given <see cref="Config"/>
+        /// </summary>
+        public static DefaultApplication GetDefaultApplication(Config config)
+        {
+            return new DefaultApplication(config);    
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Config"/> the <see cref="DefaultApplication"/> is built from
+        /// </summary>
+        public Config Config {get; } 
+
+        /// <summary>
+        /// Gets the default <see cref="IApplicationBuilder"/>.
+        /// The default structure consists of a required <see cref ="BoundedContext"/> follow by a optional <see cref="Module"/> followed by an optional <see cref="Feature"/>
+        /// followed by a recursive optional <see cref ="SubFeature"/> 
+        /// </summary>
+        /// <value></value>
+        public IApplicationBuilder ApplicationBuilder {get; }
+
+        /// <summary>
+        /// The default <see cref="IBoundedContext"/> that's generated.
+        /// </summary>
+        public IBoundedContext BoundedContext {get; }
+
+        DefaultApplication(Config config)
+        {
+            ThrowIfNoConfigurationDetails(config);
+            
+            Config = config;
+            BoundedContext = new BoundedContext(config.BoundedContextName);
+
+            ApplicationBuilder = new ApplicationBuilder(config.ApplicationName)
+                .PrefixLocationsWith(BoundedContext)
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required
+                    .WithChild<Module>(m => m
+                        .WithChild<Feature>(f => f
+                            .WithChild<SubFeature>(sf => sf.Recursive))));
+
+        }
+
+        /// <summary>
+        /// Gets the built <see cref="IApplication"/> from the <see cref="IApplicationBuilder"/>
+        /// </summary>
+        /// <returns></returns>
+        public IApplication Application => ApplicationBuilder.Build();
+
+        void ThrowIfNoConfigurationDetails(Config config)
+        {
+            if (config.ApplicationName.Equals(ApplicationName.NotSet) 
+                || config.BoundedContextName.Equals(BoundedContextName.NotSet))
+            {
+                throw new ConfigurationNotSpecified();
+            }
+        }
+    }
+}

--- a/Source/Configuration/DefaultApplicationConfiguration.cs
+++ b/Source/Configuration/DefaultApplicationConfiguration.cs
@@ -1,0 +1,76 @@
+using Dolittle.Applications;
+
+namespace Dolittle.Configuration
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DefaultApplicationConfiguration
+    {
+        
+        public static DefaultApplicationConfiguration GetDefaultConfiguration()
+        {
+            return new DefaultApplicationConfiguration(JsonFile.GetConfig());
+        }
+
+        public static DefaultApplicationConfiguration GetDefaultConfiguration(Config config)
+        {
+            return new DefaultApplicationConfiguration(config);
+        }
+
+        public static DefaultApplicationConfiguration GetDefaultConfiguration(DefaultApplication applicationConfig)
+        {
+            return new DefaultApplicationConfiguration(applicationConfig);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Config"/> the <see cref="DefaultApplicationConfiguration"/> is built from
+        /// </summary>        
+        public Config Config {get; }
+
+        /// <summary>
+        /// The default <see cref="IBoundedContext"/> that's generated.
+        /// </summary>
+        public IBoundedContext BoundedContext {get;}
+
+        /// <summary>
+        /// The default <see cref="IApplication"/> and <see cref="IApplicationStructureMap"/> based on the provided configuration details.
+        /// </summary>
+        /// <value></value>
+        public (IApplication application, IApplicationStructureMap structureMap) ApplicationConfiguration {get; }
+
+
+        DefaultApplicationConfiguration(Config config)
+        {
+            Config = config;
+
+            var defaultApplication = DefaultApplication.GetDefaultApplication(Config);
+
+            BoundedContext = defaultApplication.BoundedContext;
+
+            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.ApplicationName)
+                .Application(applicationBuilder => defaultApplication.ApplicationBuilder)
+                .StructureMappedTo(structureMapBuilder => structureMapBuilder
+                    .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.EventsAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.ReadAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.FrontendAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*"))
+                .Build();
+        }
+
+        DefaultApplicationConfiguration(DefaultApplication applicationConfig)
+        {
+            Config = applicationConfig.Config;
+            BoundedContext = applicationConfig.BoundedContext;
+
+            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.ApplicationName)
+                .Application(applicationBuilder => applicationConfig.ApplicationBuilder)
+                .StructureMappedTo(structureMapBuilder => structureMapBuilder
+                    .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.EventsAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.ReadAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
+                    .Include(Config.FrontendAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*"))
+                .Build();
+        }
+    }
+}

--- a/Source/Configuration/DefaultApplicationConfiguration.cs
+++ b/Source/Configuration/DefaultApplicationConfiguration.cs
@@ -8,15 +8,25 @@ namespace Dolittle.Configuration
     public class DefaultApplicationConfiguration
     {
         
+        /// <summary>
+        /// Gets the <see cref="DefaultApplicationConfiguration"/> based on the configuration details specified in the dolittle configuration json file.
+        /// </summary>
         public static DefaultApplicationConfiguration GetDefaultConfiguration()
         {
             return new DefaultApplicationConfiguration(JsonFile.GetConfig());
         }
 
+        /// <summary>
+        /// Gets the <see cref="DefaultApplicationConfiguration"/> based on the given <see cref="Config"/>
+        /// </summary>
         public static DefaultApplicationConfiguration GetDefaultConfiguration(Config config)
         {
             return new DefaultApplicationConfiguration(config);
         }
+
+        /// <summary>
+        /// Gets the <see cref="DefaultApplicationConfiguration"/> based on the given <see cref="DefaultApplication"/>
+        /// </summary>
 
         public static DefaultApplicationConfiguration GetDefaultConfiguration(DefaultApplication applicationConfig)
         {
@@ -48,7 +58,7 @@ namespace Dolittle.Configuration
 
             BoundedContext = defaultApplication.BoundedContext;
 
-            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.ApplicationName)
+            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.Application)
                 .Application(applicationBuilder => defaultApplication.ApplicationBuilder)
                 .StructureMappedTo(structureMapBuilder => structureMapBuilder
                     .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
@@ -63,7 +73,7 @@ namespace Dolittle.Configuration
             Config = applicationConfig.Config;
             BoundedContext = applicationConfig.BoundedContext;
 
-            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.ApplicationName)
+            ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.Application)
                 .Application(applicationBuilder => applicationConfig.ApplicationBuilder)
                 .StructureMappedTo(structureMapBuilder => structureMapBuilder
                     .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")

--- a/Source/Configuration/DefaultApplicationConfiguration.cs
+++ b/Source/Configuration/DefaultApplicationConfiguration.cs
@@ -41,7 +41,7 @@ namespace Dolittle.Configuration
         /// <summary>
         /// The default <see cref="IBoundedContext"/> that's generated.
         /// </summary>
-        public IBoundedContext BoundedContext {get;}
+        public IBoundedContext BoundedContext {get; }
 
         /// <summary>
         /// The default <see cref="IApplication"/> and <see cref="IApplicationStructureMap"/> based on the provided configuration details.
@@ -68,13 +68,13 @@ namespace Dolittle.Configuration
                 .Build();
         }
 
-        DefaultApplicationConfiguration(DefaultApplication applicationConfig)
+        DefaultApplicationConfiguration(DefaultApplication defaultApplication)
         {
-            Config = applicationConfig.Config;
-            BoundedContext = applicationConfig.BoundedContext;
+            Config = defaultApplication.Config;
+            BoundedContext = defaultApplication.BoundedContext;
 
             ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.Application)
-                .Application(applicationBuilder => applicationConfig.ApplicationBuilder)
+                .Application(applicationBuilder => defaultApplication.ApplicationBuilder)
                 .StructureMappedTo(structureMapBuilder => structureMapBuilder
                     .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
                     .Include(Config.EventsAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")

--- a/Source/Configuration/DefaultApplicationConfiguration.cs
+++ b/Source/Configuration/DefaultApplicationConfiguration.cs
@@ -7,7 +7,19 @@ namespace Dolittle.Configuration
     /// </summary>
     public class DefaultApplicationConfiguration
     {
-        
+        /// <summary>
+        /// Gets the default <see cref="IApplicationStructureMapBuilder"/> for a given <see cref="Config"/>
+        /// </summary>
+        /// <param name="config">The configuration</param>
+        /// <returns></returns>
+        public static IApplicationStructureMapBuilder GetDefaultApplicationStructureMapBuilderForConfig(Config config)
+        {
+            return new ApplicationStructureMapBuilder()
+                .Include(config.DomainAreaName   + $".-^{{{ApplicationStructureMap.ModuleKey}}}.-^{{{ApplicationStructureMap.FeatureKey}}}.-^{{{ApplicationStructureMap.SubFeatureKey}}}*")
+                .Include(config.EventsAreaName   + $".-^{{{ApplicationStructureMap.ModuleKey}}}.-^{{{ApplicationStructureMap.FeatureKey}}}.-^{{{ApplicationStructureMap.SubFeatureKey}}}*")
+                .Include(config.ReadAreaName     + $".-^{{{ApplicationStructureMap.ModuleKey}}}.-^{{{ApplicationStructureMap.FeatureKey}}}.-^{{{ApplicationStructureMap.SubFeatureKey}}}*")
+                .Include(config.FrontendAreaName + $".-^{{{ApplicationStructureMap.ModuleKey}}}.-^{{{ApplicationStructureMap.FeatureKey}}}.-^{{{ApplicationStructureMap.SubFeatureKey}}}*");
+        }
         /// <summary>
         /// Gets the <see cref="DefaultApplicationConfiguration"/> based on the configuration details specified in the dolittle configuration json file.
         /// </summary>
@@ -60,11 +72,7 @@ namespace Dolittle.Configuration
 
             ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.Application)
                 .Application(applicationBuilder => defaultApplication.ApplicationBuilder)
-                .StructureMappedTo(structureMapBuilder => structureMapBuilder
-                    .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.EventsAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.ReadAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.FrontendAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*"))
+                .StructureMappedTo(structureMapBuilder => GetDefaultApplicationStructureMapBuilderForConfig(Config))
                 .Build();
         }
 
@@ -75,11 +83,7 @@ namespace Dolittle.Configuration
 
             ApplicationConfiguration = new ApplicationConfigurationBuilder(Config.Application)
                 .Application(applicationBuilder => defaultApplication.ApplicationBuilder)
-                .StructureMappedTo(structureMapBuilder => structureMapBuilder
-                    .Include(Config.DomainAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.EventsAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.ReadAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*")
-                    .Include(Config.FrontendAreaName + ".-^{Module}.-^{Feature}.-^{SubFeature}*"))
+                .StructureMappedTo(structureMapBuilder => GetDefaultApplicationStructureMapBuilderForConfig(Config))
                 .Build();
         }
     }

--- a/Source/Configuration/JsonFile.cs
+++ b/Source/Configuration/JsonFile.cs
@@ -13,7 +13,10 @@ namespace Dolittle.Configuration
     /// </summary>
     public class JsonFile
     {
-        const string DolittleJson = "dolittle.json";
+        /// <summary>
+        /// The filename of the dolittle configuration file
+        /// </summary>
+        public static string DolittleJsonFileName = "dolittle.json";
 
         /// <summary>
         /// 
@@ -21,9 +24,9 @@ namespace Dolittle.Configuration
         /// <returns></returns>
         public static Config  GetConfig()
         {
-            if( !File.Exists(DolittleJson) ) return new Config();
+            if( !File.Exists(DolittleJsonFileName) ) return new Config();
 
-            var json = File.ReadAllText(DolittleJson);
+            var json = File.ReadAllText(DolittleJsonFileName);
             
             var config = JsonConvert.DeserializeObject(json, typeof(Config), new ConceptConverter()) as Config;
             return config;

--- a/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_and_module.cs
+++ b/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_and_module.cs
@@ -19,11 +19,11 @@ namespace Dolittle.Applications.for_ApplicationLocationResolver
         Establish context = () =>
         {
             bounded_context_match = new Mock<ISegmentMatch>();
-            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.BoundedContextKey);
+            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.BoundedContextKey);
             bounded_context_match.SetupGet(b => b.Values).Returns(new[] { BoundedContext }); 
 
             module_match = new Mock<ISegmentMatch>();
-            module_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.ModuleKey);
+            module_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.ModuleKey);
             module_match.SetupGet(b => b.Values).Returns(new[] { Module });
 
             var segments = new List<ISegmentMatch>(new[]

--- a/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_module_and_feature.cs
+++ b/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_module_and_feature.cs
@@ -21,15 +21,15 @@ namespace Dolittle.Applications.for_ApplicationLocationResolver
         Establish context = () =>
         {
             bounded_context_match = new Mock<ISegmentMatch>();
-            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.BoundedContextKey);
+            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.BoundedContextKey);
             bounded_context_match.SetupGet(b => b.Values).Returns(new[] { BoundedContext }); 
 
             module_match = new Mock<ISegmentMatch>();
-            module_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.ModuleKey);
+            module_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.ModuleKey);
             module_match.SetupGet(b => b.Values).Returns(new[] { Module });
 
             feature_match = new Mock<ISegmentMatch>();
-            feature_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.FeatureKey);
+            feature_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.FeatureKey);
             feature_match.SetupGet(b => b.Values).Returns(new[] { Feature });
 
             var segments = new List<ISegmentMatch>(new[]

--- a/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_module_feature_and_subfeature.cs
+++ b/Specifications/Applications/for_ApplicationLocationResolver/when_resolving_that_matches_bounded_context_module_feature_and_subfeature.cs
@@ -26,23 +26,23 @@ namespace Dolittle.Applications.for_ApplicationLocationResolver
         Establish context = () => 
         {           
             bounded_context_match = new Mock<ISegmentMatch>();
-            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.BoundedContextKey);
+            bounded_context_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.BoundedContextKey);
             bounded_context_match.SetupGet(b => b.Values).Returns(new[] { BoundedContext }); 
 
             module_match = new Mock<ISegmentMatch>();
-            module_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.ModuleKey);
+            module_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.ModuleKey);
             module_match.SetupGet(b => b.Values).Returns(new[] { Module });
 
             feature_match = new Mock<ISegmentMatch>();
-            feature_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.FeatureKey);
+            feature_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.FeatureKey);
             feature_match.SetupGet(b => b.Values).Returns(new[] { Feature });
 
             first_subfeature_match = new Mock<ISegmentMatch>();
-            first_subfeature_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.SubFeatureKey);
+            first_subfeature_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.SubFeatureKey);
             first_subfeature_match.SetupGet(b => b.Values).Returns(new[] { TopLevelSubFeature });
 
             second_subfeature_match = new Mock<ISegmentMatch>();
-            second_subfeature_match.SetupGet(b => b.Identifier).Returns(ApplicationLocationResolver.SubFeatureKey);
+            second_subfeature_match.SetupGet(b => b.Identifier).Returns(ApplicationStructureMap.SubFeatureKey);
             second_subfeature_match.SetupGet(b => b.Values).Returns(new[] { SecondLevelSubFeature });
 
             var segments = new List<ISegmentMatch>(new[]


### PR DESCRIPTION
Dolittle.Configuration can now provide with a default Application configuration given that you have defined a dolittle.json config file or created an instance of Dolittle.Configuration.Config

fixes #22 
fixes #14 