### PR TITLE
Command Handler Invoker returns false if fails

### DIFF
--- a/Source/Commands.Handling/CommandHandlerInvoker.cs
+++ b/Source/Commands.Handling/CommandHandlerInvoker.cs
@@ -112,6 +112,7 @@ namespace Dolittle.Commands.Handling
                 catch (Exception ex)
                 {
                     _logger.Error(ex, $"Failed invoking command handler '{commandHandlerType.AssemblyQualifiedName}' for command of type '{command.Type}'");
+                    return false;
                 }
                 return true;
             }


### PR DESCRIPTION
We were catching and logging the error but failing to return false.  The caller then receives a CommandResult saying it was successful and thinks everything was ok.

Just return false from the Exception handler.