### PR TITLE
Fixing Topology configuration to be more in line with what we want -

### DIFF
--- a/Source/AggregatedPackage/SDK.csproj
+++ b/Source/AggregatedPackage/SDK.csproj
@@ -12,6 +12,8 @@
     <ItemGroup>
         <PackageReference Include="Dolittle.Serialization.Json" Version="2.0.0-*" />
         <PackageReference Include="Dolittle.Concepts.Serialization.Json" Version="2.0.0-*" />
+        <PackageReference Include="Dolittle.Concepts.Serialization.Protobuf" Version="2.0.0-*" />
+        <PackageReference Include="Dolittle.Configuration.Files" Version="2.0.0-*" />
     </ItemGroup>
 </Project>
 

--- a/Source/Applications.Configuration/FeatureDefinition.cs
+++ b/Source/Applications.Configuration/FeatureDefinition.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Dolittle.Applications.Configuration
 {
@@ -12,19 +13,25 @@ namespace Dolittle.Applications.Configuration
     public class FeatureDefinition 
     {
         /// <summary>
-        /// Gets or sets the <see cref="Feature"/>
+        /// Initializes a new instance of <see cref="FeatureDefinition"/>
         /// </summary>
-        public Feature Feature { get; set; }
+        /// <param name="name"><see cref="FeatureName">Name</see> of the featurew</param>
+        /// <param name="subFeatures">Key/Value pairs of features and their definitions for any sub-features</param>
+        public FeatureDefinition(FeatureName name, IDictionary<Feature, FeatureDefinition> subFeatures)
+        {
+            Name = name;
+            SubFeatures = new ReadOnlyDictionary<Feature, FeatureDefinition>(subFeatures);
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="FeatureName">name of the feature</see>
         /// </summary>
-        public FeatureName Name { get; set; }
+        public FeatureName Name { get; }
+
 
         /// <summary>
-        /// Gets or sets the <see cref="IEnumerable{FeatureDefinition}">collection of child</see> <see cref="FeatureDefinition">features</see>
+        /// Gets the <see cref="IEnumerable{FeatureDefinition}">sub features</see> that exists
         /// </summary>
-        /// <value></value>
-        public IEnumerable<FeatureDefinition>   SubFeatures { get; set; } = new FeatureDefinition[0];
+        public ReadOnlyDictionary<Feature,FeatureDefinition> SubFeatures { get; }
     }
 }

--- a/Source/Applications.Configuration/ModuleDefinition.cs
+++ b/Source/Applications.Configuration/ModuleDefinition.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Dolittle.Applications.Configuration
 {
@@ -12,19 +13,24 @@ namespace Dolittle.Applications.Configuration
     public class ModuleDefinition
     {
         /// <summary>
-        /// Gets or sets the <see cref="Module"/>
+        /// Initializes a new instance of <see cref="ModuleDefinition"/>
         /// </summary>
-        public Module   Module { get; set; }
+        /// <param name="name"><see cref="ModuleName">Name</see> of the module</param>
+        /// <param name="features">Key/values of features and their definitions</param>
+        public ModuleDefinition(ModuleName name, IDictionary<Feature, FeatureDefinition> features)
+        {
+            Name = name;
+            Features = new ReadOnlyDictionary<Feature, FeatureDefinition>(features);
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="ModuleName">name of the module</see>
         /// </summary>
-        public ModuleName Name { get; set; }
+        public ModuleName Name { get; }
 
         /// <summary>
         /// Gets or sets a <see cref="IEnumerable{FeatureDefinition}">collection</see> of <see cref="FeatureDefinition"/>
         /// </summary>
-        /// <value></value>
-        public IEnumerable<FeatureDefinition> Features { get; set; } = new FeatureDefinition[0];
+        public ReadOnlyDictionary<Feature, FeatureDefinition> Features { get; }
     }
 }

--- a/Source/Applications.Configuration/Topology.cs
+++ b/Source/Applications.Configuration/Topology.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Dolittle.Configuration;
 
 namespace Dolittle.Applications.Configuration
@@ -18,22 +19,21 @@ namespace Dolittle.Applications.Configuration
         /// <param name="modules">Collection of <see cref="ModuleDefinition">modules</see>></param>
         /// <param name="features">Collection of <see cref="FeatureDefinition">features</see></param>
         public Topology(
-            IEnumerable<ModuleDefinition> modules,
-            IEnumerable<FeatureDefinition> features)
+            IDictionary<Module, ModuleDefinition> modules,
+            IDictionary<Feature, FeatureDefinition> features)
         {
-            Modules = modules;
-            Features = features;
+            Modules = new ReadOnlyDictionary<Module, ModuleDefinition>(modules);
+            Features = new ReadOnlyDictionary<Feature, FeatureDefinition>(features);
         }
-    
 
         /// <summary>
         /// Gets a <see cref="IEnumerable{ModuleDefinition}">collection</see> of <see cref="ModuleDefinition"/>
         /// </summary>
-        public IEnumerable<ModuleDefinition> Modules { get; }
+        public ReadOnlyDictionary<Module, ModuleDefinition> Modules { get; }
 
         /// <summary>
         /// Gets the <see cref="IEnumerable{FeatureDefinition}">features</see> that exists in the root
         /// </summary>
-        public IEnumerable<FeatureDefinition> Features { get; }
+        public ReadOnlyDictionary<Feature,FeatureDefinition> Features { get; }
     }
 }

--- a/Source/Build/Artifact/ArtifactsConfigurationBuilder.cs
+++ b/Source/Build/Artifact/ArtifactsConfigurationBuilder.cs
@@ -85,7 +85,12 @@ namespace Dolittle.Build.Artifact
             return _artifactsConfiguration;
         }
 
-        int HandleArtifactOfType(Type artifactType, BoundedContextTopology boundedContextConfiguration, string artifactTypeName, Expression<Func<ArtifactsByTypeDefinition, IEnumerable<ArtifactDefinition>> > targetPropertyExpression, ref List<string> nonMatchingArtifacts)
+        int HandleArtifactOfType(
+            Type artifactType,
+            BoundedContextTopology boundedContextConfiguration,
+            string artifactTypeName,
+            Expression<Func<ArtifactsByTypeDefinition, IEnumerable<ArtifactDefinition>>> targetPropertyExpression,
+            ref List<string> nonMatchingArtifacts)
         {
             var targetProperty = targetPropertyExpression.GetPropertyInfo();
 
@@ -95,16 +100,16 @@ namespace Dolittle.Build.Artifact
             foreach (var artifact in artifacts)
             {
                 var feature = boundedContextConfiguration.FindMatchingFeature(artifact.Namespace, ref nonMatchingArtifacts);
-                if (feature != null)
+                if (feature.Value != null)
                 {
                     ArtifactsByTypeDefinition artifactsByTypeDefinition;
 
-                    if (_artifactsConfiguration.Artifacts.ContainsKey(feature.Feature))
-                        artifactsByTypeDefinition = _artifactsConfiguration.Artifacts[feature.Feature];
+                    if (_artifactsConfiguration.Artifacts.ContainsKey(feature.Key))
+                        artifactsByTypeDefinition = _artifactsConfiguration.Artifacts[feature.Key];
                     else
                     {
                         artifactsByTypeDefinition = new ArtifactsByTypeDefinition();
-                        _artifactsConfiguration.Artifacts[feature.Feature] = artifactsByTypeDefinition;
+                        _artifactsConfiguration.Artifacts[feature.Key] = artifactsByTypeDefinition;
                     } 
                     var existingArtifacts = targetProperty.GetValue(artifactsByTypeDefinition) as IEnumerable<ArtifactDefinition>;
                     

--- a/Source/Build/Artifact/BoundedContextConfigurationExtensions.cs
+++ b/Source/Build/Artifact/BoundedContextConfigurationExtensions.cs
@@ -19,11 +19,10 @@ namespace Dolittle.Build.Artifact
         /// <summary>
         /// Returns all <see cref="FeatureDefinition"/> from the <see cref="Applications.Configuration.Topology"/>
         /// </summary>
-        public static IEnumerable<FeatureDefinition> RetrieveFeatures(this BoundedContextTopology configuration)
+        public static IDictionary<Feature, FeatureDefinition> RetrieveFeatures(this BoundedContextTopology configuration)
         {
-            if (configuration.UseModules) return configuration.Topology.Modules.SelectMany(_ => _.Features);     
+            if (configuration.UseModules) return configuration.Topology.Modules.SelectMany(_ => _.Value.Features).ToDictionary(_ => _.Key, _ => _.Value);
             else return  configuration.Topology.Features;
-            
         }
 
         /// <summary>
@@ -40,17 +39,17 @@ namespace Dolittle.Build.Artifact
         /// <summary>
         /// Returns a <see cref="FeatureDefinition"/> that matches the artifact with the given namespace based on the <see cref="BoundedContextTopology">BoundedContextConfiguration's </see> topology 
         /// </summary>
-        public static FeatureDefinition FindMatchingFeature(this BoundedContextTopology boundedContextConfiguration, string @namespace)
+        public static KeyValuePair<Feature, FeatureDefinition> FindMatchingFeature(this BoundedContextTopology boundedContextConfiguration, string @namespace)
         {
             var nonMatchingList = new List<string>();
             var featureDef = boundedContextConfiguration.FindMatchingFeature(@namespace, ref nonMatchingList);
-            if (featureDef == null) throw new NonMatchingArtifact();
+            if (featureDef.Key == null) throw new NonMatchingArtifact();
             return featureDef;
         }
         /// <summary>
         /// Returns a <see cref="FeatureDefinition"/> that matches the artifact with the given namespace based on the <see cref="BoundedContextTopology">BoundedContextConfiguration's </see> topology 
         /// </summary>
-        public static FeatureDefinition FindMatchingFeature(this BoundedContextTopology boundedContextConfiguration, string @namespace, ref List<string> nonMatchingArtifacts)
+        public static KeyValuePair<Feature, FeatureDefinition> FindMatchingFeature(this BoundedContextTopology boundedContextConfiguration, string @namespace, ref List<string> nonMatchingArtifacts)
         {
             var area = new Area(){Value = @namespace.Split(".").First()};
             var segments = @namespace.Split(".").Skip(1).ToArray();
@@ -66,16 +65,16 @@ namespace Dolittle.Build.Artifact
             if (boundedContextConfiguration.UseModules)
             {
                 var matchingModule = boundedContextConfiguration.Topology.Modules
-                    .SingleOrDefault(module => module.Name.Value.Equals(segments[0]));
+                    .SingleOrDefault(module => module.Value.Name.Value.Equals(segments[0]));
                 
                 try
                 {
-                    return FindMatchingFeature(segments.Skip(1).ToArray(), matchingModule.Features);
+                    return FindMatchingFeature(segments.Skip(1).ToArray(), matchingModule.Value.Features);
                 } 
                 catch (Exception)
                 {
                     nonMatchingArtifacts.Add(@namespace);
-                    return null;
+                    return new KeyValuePair<Feature, FeatureDefinition>(null, null);
                 }
             }
             try 
@@ -85,32 +84,32 @@ namespace Dolittle.Build.Artifact
             catch(Exception)
             {
                 nonMatchingArtifacts.Add(@namespace);
-                return null;
+                return new KeyValuePair<Feature, FeatureDefinition>(null, null);
             }
         }
 
-        static FeatureDefinition FindMatchingFeature(string[] segments, IEnumerable<FeatureDefinition> features)
+        static KeyValuePair<Feature, FeatureDefinition> FindMatchingFeature(string[] segments, IDictionary<Feature, FeatureDefinition> features)
         {
             var featureName = segments.Count() > 0? segments[0] : "";
             if (string.IsNullOrEmpty(featureName)) 
                 throw new Exception("Missing feature");
             
-            var matchingFeature = features.SingleOrDefault(feature => feature.Name.Value.Equals(segments[0]));
+            Func<KeyValuePair<Feature, FeatureDefinition>, bool>  predicate = (KeyValuePair<Feature, FeatureDefinition> feature) => feature.Value.Name.Value.Equals(segments[0]);
+            if( !features.Any(predicate) )  throw new Exception("Missing feature");
 
-            if (matchingFeature == null) 
-                throw new Exception("Missing feature");
+            var matchingFeature = features.SingleOrDefault(predicate);
 
             if (segments.Count() == 1) return matchingFeature;
 
-            return FindMatchingFeature(segments.Skip(1).ToArray(), matchingFeature.SubFeatures);
+            return FindMatchingFeature(segments.Skip(1).ToArray(), matchingFeature.Value.SubFeatures);
         }
         
-        static void AddAllFeaturesToMap(IEnumerable<FeatureDefinition> features, ref Dictionary<Feature, FeatureName> map)
+        static void AddAllFeaturesToMap(IDictionary<Feature,FeatureDefinition> features, ref Dictionary<Feature, FeatureName> map)
         {
             foreach (var feature in features)
             {
-                map.Add(feature.Feature, feature.Name);
-                AddAllFeaturesToMap(feature.SubFeatures, ref map);
+                map.Add(feature.Key, feature.Value.Name);
+                AddAllFeaturesToMap(feature.Value.SubFeatures, ref map);
             }
         }
     }

--- a/Source/Build/Topology/TopologyBuilder.cs
+++ b/Source/Build/Topology/TopologyBuilder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 using Dolittle.Collections;
@@ -92,7 +93,7 @@ namespace Dolittle.Build.Topology
             if (_configuration.UseModules ) 
             {
                foreach (var module in _configuration.Topology.Modules)
-                   existingArtifactPaths.AddRange(GetArtifactPathsFor(module.Features, module.Name));
+                   existingArtifactPaths.AddRange(GetArtifactPathsFor(module.Value.Features, module.Value.Name));
             }
             else 
                 existingArtifactPaths.AddRange(GetArtifactPathsFor(_configuration.Topology.Features));
@@ -111,26 +112,32 @@ namespace Dolittle.Build.Topology
 
         void AddModulesAndFeatures(string[] missingPaths)
         {
-            var modules = new List<ModuleDefinition>(_configuration.Topology.Modules);
+            var modules = new Dictionary<Module, ModuleDefinition>(_configuration.Topology.Modules);
 
             foreach(var path in missingPaths)
-                modules.Add(path.GetModuleFromPath());
+            {
+                var keyValue = path.GetModuleFromPath();
+                modules.Add(keyValue.Key, keyValue.Value);
+            }
 
             _configuration.Topology = new Dolittle.Applications.Configuration.Topology(modules.GetCollapsedModules(), _configuration.Topology.Features);
         }
 
         void AddFeatures(string[] missingPaths)
         {
-            var features = new List<FeatureDefinition>(_configuration.Topology.Features);
+            var features = new Dictionary<Feature, FeatureDefinition>(_configuration.Topology.Features);
             foreach (var path in missingPaths)
-                features.Add(path.GetFeatureFromPath());
+            {
+                var keyValue = path.GetFeatureFromPath();
+                features.Add(keyValue.Key, keyValue.Value);
+            }
 
             _configuration.Topology = new Dolittle.Applications.Configuration.Topology(_configuration.Topology.Modules, features.GetCollapsedFeatures());
         }
-        static IEnumerable<string> GetArtifactPathsFor(IEnumerable<FeatureDefinition> features, string parent = "")
+        static IEnumerable<string> GetArtifactPathsFor(IDictionary<Feature,FeatureDefinition> features, string parent = "")
         {
             var paths = new List<string>();
-            features.ForEach(_ =>
+            features.Values.ForEach(_ =>
             {
                 var featurePath = new List<string>();
                 if( !string.IsNullOrEmpty(parent) ) featurePath.Add($"{parent}");

--- a/Source/Build/Topology/TopologyConfigurationManager.cs
+++ b/Source/Build/Topology/TopologyConfigurationManager.cs
@@ -8,6 +8,8 @@ using Dolittle.Logging;
 using Dolittle.Serialization.Json;
 using Newtonsoft.Json;
 using Dolittle.Applications.Configuration;
+using System.Collections.Generic;
+using Dolittle.Applications;
 
 namespace Dolittle.Build.Topology
 {
@@ -43,7 +45,9 @@ namespace Dolittle.Build.Topology
         public Dolittle.Applications.Configuration.Topology Load()
         {
             var path = GetPath();
-            if( !File.Exists(path)) return new Dolittle.Applications.Configuration.Topology(new ModuleDefinition[0], new FeatureDefinition[0]);
+            if( !File.Exists(path)) return new Dolittle.Applications.Configuration.Topology(
+                new Dictionary<Module, ModuleDefinition>(), 
+                new Dictionary<Feature, FeatureDefinition>());
             
             var json = File.ReadAllText(path);
             var configuration = _serializer.FromJson<Dolittle.Applications.Configuration.Topology>(json, _serializationOptions);

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_not_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_not_using_modules/given/a_bounded_context_config.cs
@@ -19,10 +19,11 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactConfigurationBuilder.
         protected static BoundedContextTopology bounded_context_config;
         Establish context = () => 
         {
-            var topology = new Applications.Configuration.Topology(new ModuleDefinition[0], new []
+            var topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>(), 
+            new Dictionary<Feature, FeatureDefinition>
             {
-                new FeatureDefinition(){Feature = first_feature, Name = "Feature"},
-                new FeatureDefinition(){Feature = second_feature, Name = "Feature3"}
+                { first_feature, new FeatureDefinition( "Feature", new Dictionary<Feature, FeatureDefinition>()) },
+                { second_feature, new FeatureDefinition( "Feature 3", new Dictionary<Feature, FeatureDefinition>()) }
             });
             
             bounded_context_config = new BoundedContextTopology(topology, false, new Dictionary<Area, IEnumerable<string>>());

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_not_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_not_using_modules/given/a_bounded_context_config.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactConfigurationBuilder.
             new Dictionary<Feature, FeatureDefinition>
             {
                 { first_feature, new FeatureDefinition( "Feature", new Dictionary<Feature, FeatureDefinition>()) },
-                { second_feature, new FeatureDefinition( "Feature 3", new Dictionary<Feature, FeatureDefinition>()) }
+                { second_feature, new FeatureDefinition( "Feature3", new Dictionary<Feature, FeatureDefinition>()) }
             });
             
             bounded_context_config = new BoundedContextTopology(topology, false, new Dictionary<Area, IEnumerable<string>>());

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_using_modules/given/a_bounded_context_config.cs
@@ -19,11 +19,16 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactConfigurationBuilder.
         protected static BoundedContextTopology bounded_context_config;
         Establish context = () =>
         {
-            var topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>(),
-                new Dictionary<Feature, FeatureDefinition>
-                { { first_feature, new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>()) },
-                    { second_feature, new FeatureDefinition("Feature 3", new Dictionary<Feature, FeatureDefinition>()) }
-                });
+            var topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>
+            {
+                { 
+                    Guid.NewGuid(), new ModuleDefinition("Module", new Dictionary<Feature, FeatureDefinition>
+                    { 
+                        { first_feature, new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>()) },
+                        { second_feature, new FeatureDefinition("Feature3", new Dictionary<Feature, FeatureDefinition>()) }
+                    })
+                }
+            }, new Dictionary<Feature, FeatureDefinition>());
 
             bounded_context_config = new BoundedContextTopology(topology, true, new Dictionary<Area, IEnumerable<string>>());
         };

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationBuilder/when_using_modules/given/a_bounded_context_config.cs
@@ -16,19 +16,15 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactConfigurationBuilder.
 {
     public class a_bounded_context_config : all_dependencies
     {
-         protected static BoundedContextTopology bounded_context_config;
-        Establish context = () => 
+        protected static BoundedContextTopology bounded_context_config;
+        Establish context = () =>
         {
-            var modules = new []
-            {
-                new ModuleDefinition(){Module = Guid.NewGuid(), Name = "Module", Features = new []
-                {
-                    new FeatureDefinition(){Feature = first_feature, Name = "Feature"},
-                    new FeatureDefinition(){Feature = second_feature, Name = "Feature3"}
-                }}
-            };
-            var topology = new Applications.Configuration.Topology(modules, new FeatureDefinition[0]);
-            
+            var topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>(),
+                new Dictionary<Feature, FeatureDefinition>
+                { { first_feature, new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>()) },
+                    { second_feature, new FeatureDefinition("Feature 3", new Dictionary<Feature, FeatureDefinition>()) }
+                });
+
             bounded_context_config = new BoundedContextTopology(topology, true, new Dictionary<Area, IEnumerable<string>>());
         };
     }

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationExtensions/for_ValidateArtifacts/when_not_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationExtensions/for_ValidateArtifacts/when_not_using_modules/given/a_bounded_context_config.cs
@@ -19,10 +19,11 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactsConfigurationExtensi
         protected static BoundedContextTopology bounded_context_config;
         Establish context = () => 
         {
-            var topology = new Applications.Configuration.Topology(new ModuleDefinition[0], new []
+            var topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>(), 
+            new Dictionary<Feature, FeatureDefinition>
             {
-                new FeatureDefinition(){Feature = feature1, Name = "Feature"},
-                new FeatureDefinition(){Feature = feature2, Name = "Feature3"}
+                { feature1, new FeatureDefinition( "Feature", new Dictionary<Feature, FeatureDefinition>()) },
+                { feature2, new FeatureDefinition( "Feature3", new Dictionary<Feature, FeatureDefinition>()) }
             });
             
             bounded_context_config = new BoundedContextTopology(topology,false, new Dictionary<Area, IEnumerable<string>>());

--- a/Specifications/Build/for_Artifact/for_ArtifactsConfigurationExtensions/for_ValidateArtifacts/when_using_modules/given/a_bounded_context_config.cs
+++ b/Specifications/Build/for_Artifact/for_ArtifactsConfigurationExtensions/for_ValidateArtifacts/when_using_modules/given/a_bounded_context_config.cs
@@ -17,18 +17,20 @@ namespace Dolittle.Build.Artifact.for_Artifact.for_ArtifactsConfigurationExtensi
     public class a_bounded_context_config : all_dependencies
     {
         protected static BoundedContextTopology bounded_context_config;
-        Establish context = () => 
+        Establish context = () =>
         {
-            var modules = new []
-            {
-                new ModuleDefinition(){Module = Guid.NewGuid(), Name = "Module", Features = new []
+            var topology = new Applications.Configuration.Topology(
+                new Dictionary<Module, ModuleDefinition>
                 {
-                    new FeatureDefinition(){Feature = feature1, Name = "Feature"},
-                    new FeatureDefinition(){Feature = feature2, Name = "Feature3"}
-                }}
-            };
-            var topology = new Applications.Configuration.Topology(modules, new FeatureDefinition[0]);
-            
+                    {
+                        Guid.NewGuid(),
+                            new ModuleDefinition("Module", new Dictionary<Feature, FeatureDefinition>
+                            { { feature1, new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>()) },
+                                { feature2, new FeatureDefinition("Feature3", new Dictionary<Feature, FeatureDefinition>()) }
+                            })
+                    }
+                }, new Dictionary<Feature, FeatureDefinition>());
+
             bounded_context_config = new BoundedContextTopology(topology, true, new Dictionary<Area, IEnumerable<string>>());
         };
     }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_one_feature.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_one_feature.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -15,7 +16,7 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetFeatu
         static readonly string feature1_name = "Feature1";
         static readonly string feature_path = $"{feature1_name}";
 
-        static FeatureDefinition feature_definition;
+        static KeyValuePair<Feature,FeatureDefinition> feature_definition;
         Because of = () => 
         {
             feature_definition = feature_path.GetFeatureFromPath();
@@ -23,9 +24,9 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetFeatu
         };
 
         It should_generate_a_feature_definition = () => feature_definition.ShouldNotBeNull();
-        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Name.ShouldEqual((FeatureName)feature1_name);
-        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_first_feature_definition_with_no_sub_features = () => feature_definition.SubFeatures.Count().ShouldEqual(0);
+        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Value.Name.ShouldEqual((FeatureName)feature1_name);
+        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_first_feature_definition_with_no_sub_features = () => feature_definition.Value.SubFeatures.Count().ShouldEqual(0);
 
     }
 }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_three_features.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_three_features.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -17,24 +18,24 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetFeatu
         static readonly string feature3_name = "Feature3";
         static readonly string feature_path = $"{feature1_name}.{feature2_name}.{feature3_name}";
 
-        static FeatureDefinition feature_definition;
+        static KeyValuePair<Feature,FeatureDefinition> feature_definition;
         Because of = () => 
         {
             feature_definition = feature_path.GetFeatureFromPath();
         };
 
         It should_generate_a_feature_definition = () => feature_definition.ShouldNotBeNull();
-        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Name.ShouldEqual((FeatureName)feature1_name);
-        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_first_feature_definition_with_one_sub_feature = () => feature_definition.SubFeatures.Count().ShouldEqual(1);
+        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Value.Name.ShouldEqual((FeatureName)feature1_name);
+        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_first_feature_definition_with_one_sub_feature = () => feature_definition.Value.SubFeatures.Count().ShouldEqual(1);
 
-        It should_should_have_second_feature_definition_with_correct_name = () => feature_definition.SubFeatures.First().Name.ShouldEqual((FeatureName)feature2_name);
-        It should_should_have_second_feature_definition_with_valid_feature_id = () => feature_definition.SubFeatures.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_second_feature_definition_with_one_sub_features = () => feature_definition.SubFeatures.First().SubFeatures.Count().ShouldEqual(1);
+        It should_should_have_second_feature_definition_with_correct_name = () => feature_definition.Value.SubFeatures.First().Value.Name.ShouldEqual((FeatureName)feature2_name);
+        It should_should_have_second_feature_definition_with_valid_feature_id = () => feature_definition.Value.SubFeatures.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_second_feature_definition_with_one_sub_features = () => feature_definition.Value.SubFeatures.First().Value.SubFeatures.Count().ShouldEqual(1);
         
-        It should_should_have_third_feature_definition_with_correct_name = () => feature_definition.SubFeatures.First().SubFeatures.First().Name.ShouldEqual((FeatureName)feature3_name);
-        It should_should_have_third_feature_definition_with_valid_feature_id = () => feature_definition.SubFeatures.First().SubFeatures.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_third_feature_definition_with_no_sub_features = () => feature_definition.SubFeatures.First().SubFeatures.First().SubFeatures.Count().ShouldEqual(0);
+        It should_should_have_third_feature_definition_with_correct_name = () => feature_definition.Value.SubFeatures.First().Value.SubFeatures.First().Value.Name.ShouldEqual((FeatureName)feature3_name);
+        It should_should_have_third_feature_definition_with_valid_feature_id = () => feature_definition.Value.SubFeatures.First().Value.SubFeatures.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_third_feature_definition_with_no_sub_features = () => feature_definition.Value.SubFeatures.First().Value.SubFeatures.First().Value.SubFeatures.Count().ShouldEqual(0);
 
 
     }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_two_features.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetFeatureFromPath/when_getting_feature_from_path_with_two_features.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -16,7 +17,7 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetFeatu
         static readonly string feature2_name = "Feature2";
         static readonly string feature_path = $"{feature1_name}.{feature2_name}";
 
-        static FeatureDefinition feature_definition;
+        static KeyValuePair<Feature,FeatureDefinition> feature_definition;
         Because of = () => 
         {
             feature_definition = feature_path.GetFeatureFromPath();
@@ -24,13 +25,13 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetFeatu
         };
 
         It should_generate_a_feature_definition = () => feature_definition.ShouldNotBeNull();
-        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Name.ShouldEqual((FeatureName)feature1_name);
-        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_first_feature_definition_with_one_sub_feature = () => feature_definition.SubFeatures.Count().ShouldEqual(1);
+        It should_should_have_first_feature_definition_with_correct_name = () => feature_definition.Value.Name.ShouldEqual((FeatureName)feature1_name);
+        It should_should_have_first_feature_definition_with_valid_feature_id = () => feature_definition.Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_first_feature_definition_with_one_sub_feature = () => feature_definition.Value.SubFeatures.Count().ShouldEqual(1);
 
-        It should_should_have_second_feature_definition_with_correct_name = () => feature_definition.SubFeatures.First().Name.ShouldEqual((FeatureName)feature2_name);
-        It should_should_have_second_feature_definition_with_valid_feature_id = () => feature_definition.SubFeatures.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_second_feature_definition_with_no_sub_features = () => feature_definition.SubFeatures.First().SubFeatures.Count().ShouldEqual(0);
+        It should_should_have_second_feature_definition_with_correct_name = () => feature_definition.Value.SubFeatures.First().Value.Name.ShouldEqual((FeatureName)feature2_name);
+        It should_should_have_second_feature_definition_with_valid_feature_id = () => feature_definition.Value.SubFeatures.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_second_feature_definition_with_no_sub_features = () => feature_definition.Value.SubFeatures.First().Value.SubFeatures.Count().ShouldEqual(0);
 
     }
 }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_no_feature.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_no_feature.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -15,13 +16,13 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetModul
     {
          static readonly string path = $"{module_name}";
 
-        static ModuleDefinition module_definition;
+        static KeyValuePair<Module,ModuleDefinition> module_definition;
 
         Because of = () => module_definition = path.GetModuleFromPath();
 
         It should_get_a_module_definition = () => module_definition.ShouldNotBeNull();
-        It should_have_the_correct_module_name = () => module_definition.Name.ShouldEqual((ModuleName)module_name);
-        It should_have_a_valid_module_id = () => module_definition.Module.ShouldNotEqual((Module)Guid.Empty);
-        It should_have_one_feature = () => module_definition.Features.Count().ShouldEqual(0);
+        It should_have_the_correct_module_name = () => module_definition.Value.Name.ShouldEqual((ModuleName)module_name);
+        It should_have_a_valid_module_id = () => module_definition.Key.ShouldNotEqual((Module)Guid.Empty);
+        It should_have_one_feature = () => module_definition.Value.Features.Count().ShouldEqual(0);
     }
 }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_one_feature.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_one_feature.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -16,18 +17,18 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetModul
         static readonly string feature1_name = "Feature1"; 
         static readonly string path = $"{module_name}.{feature1_name}";
 
-        static ModuleDefinition module_definition;
+        static KeyValuePair<Module,ModuleDefinition> module_definition;
 
         Because of = () => module_definition = path.GetModuleFromPath();
 
         It should_get_a_module_definition = () => module_definition.ShouldNotBeNull();
-        It should_have_the_correct_module_name = () => module_definition.Name.ShouldEqual((ModuleName)module_name);
-        It should_have_a_valid_module_id = () => module_definition.Module.ShouldNotEqual((Module)Guid.Empty);
-        It should_have_one_feature = () => module_definition.Features.Count().ShouldEqual(1);
+        It should_have_the_correct_module_name = () => module_definition.Value.Name.ShouldEqual((ModuleName)module_name);
+        It should_have_a_valid_module_id = () => module_definition.Key.ShouldNotEqual((Module)Guid.Empty);
+        It should_have_one_feature = () => module_definition.Value.Features.Count().ShouldEqual(1);
         
-        It should_should_have_first_feature_definition_with_correct_name = () => module_definition.Features.First().Name.ShouldEqual((FeatureName)feature1_name);
-        It should_should_have_first_feature_definition_with_valid_feature_id = () => module_definition.Features.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_first_feature_definition_with_no_sub_features = () => module_definition.Features.First().SubFeatures.Count().ShouldEqual(0);
+        It should_should_have_first_feature_definition_with_correct_name = () => module_definition.Value.Features.First().Value.Name.ShouldEqual((FeatureName)feature1_name);
+        It should_should_have_first_feature_definition_with_valid_feature_id = () => module_definition.Value.Features.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_first_feature_definition_with_no_sub_features = () => module_definition.Value.Features.First().Value.SubFeatures.Count().ShouldEqual(0);
         
     }
 }

--- a/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_two_features.cs
+++ b/Specifications/Build/for_Topology/for_StringExtensions/for_GetModuleFromPath/when_getting_module_from_path_with_module_and_two_features.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
@@ -17,22 +18,22 @@ namespace Dolittle.Build.Topology.for_Topology.for_StringExtensions.for_GetModul
         static readonly string feature2_name = "Feature2";
         static readonly string path = $"{module_name}.{feature1_name}.{feature2_name}";
 
-        static ModuleDefinition module_definition;
+        static KeyValuePair<Module,ModuleDefinition> module_definition;
 
         Because of = () => module_definition = path.GetModuleFromPath();
 
         It should_get_a_module_definition = () => module_definition.ShouldNotBeNull();
-        It should_have_the_correct_module_name = () => module_definition.Name.ShouldEqual((ModuleName)module_name);
-        It should_have_a_valid_module_id = () => module_definition.Module.ShouldNotEqual((Module)Guid.Empty);
-        It should_have_one_feature = () => module_definition.Features.Count().ShouldEqual(1);
+        It should_have_the_correct_module_name = () => module_definition.Value.Name.ShouldEqual((ModuleName)module_name);
+        It should_have_a_valid_module_id = () => module_definition.Key.ShouldNotEqual((Module)Guid.Empty);
+        It should_have_one_feature = () => module_definition.Value.Features.Count().ShouldEqual(1);
         
-        It should_should_have_first_feature_definition_with_correct_name = () => module_definition.Features.First().Name.ShouldEqual((FeatureName)feature1_name);
-        It should_should_have_first_feature_definition_with_valid_feature_id = () => module_definition.Features.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_first_feature_definition_with_one_sub_feature = () => module_definition.Features.First().SubFeatures.Count().ShouldEqual(1);
+        It should_should_have_first_feature_definition_with_correct_name = () => module_definition.Value.Features.First().Value.Name.ShouldEqual((FeatureName)feature1_name);
+        It should_should_have_first_feature_definition_with_valid_feature_id = () => module_definition.Value.Features.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_first_feature_definition_with_one_sub_feature = () => module_definition.Value.Features.First().Value.SubFeatures.Count().ShouldEqual(1);
 
-        It should_should_have_second_feature_definition_with_correct_name = () => module_definition.Features.First().SubFeatures.First().Name.ShouldEqual((FeatureName)feature2_name);
-        It should_should_have_second_feature_definition_with_valid_feature_id = () => module_definition.Features.First().SubFeatures.First().Feature.ShouldNotEqual((Feature)Guid.Empty);
-        It should_should_have_second_feature_definition_with_no_sub_features = () => module_definition.Features.First().SubFeatures.First().SubFeatures.Count().ShouldEqual(0);
+        It should_should_have_second_feature_definition_with_correct_name = () => module_definition.Value.Features.First().Value.SubFeatures.First().Value.Name.ShouldEqual((FeatureName)feature2_name);
+        It should_should_have_second_feature_definition_with_valid_feature_id = () => module_definition.Value.Features.First().Value.SubFeatures.First().Key.ShouldNotEqual((Feature)Guid.Empty);
+        It should_should_have_second_feature_definition_with_no_sub_features = () => module_definition.Value.Features.First().Value.SubFeatures.First().Value.SubFeatures.Count().ShouldEqual(0);
         
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,8 +13,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), false, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,8 +13,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), false, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_all_artifacts_are_valid.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_all_artifacts_are_valid.cs
@@ -19,12 +19,12 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
         It should_generate_a_topology_with_features = () => topology.Features.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_modules = () => topology.Modules.ShouldBeEmpty();
         It should_generate_a_topology_with_two_top_level_features = () => topology.Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
         
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_there_is_an_artifact_not_matching_the_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_there_is_an_artifact_not_matching_the_topology.cs
@@ -19,11 +19,11 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
         It should_generate_a_topology_with_features = () => topology.Features.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_modules = () => topology.Modules.ShouldBeEmpty();
         It should_generate_a_topology_with_two_top_level_features = () => topology.Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), false, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), false, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_all_artifacts_are_valid.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_all_artifacts_are_valid.cs
@@ -19,12 +19,12 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
         It should_generate_a_topology_with_features = () => topology.Features.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_modules = () => topology.Modules.ShouldBeEmpty();
         It should_generate_a_topology_with_two_top_level_features = () => topology.Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
         
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_there_is_an_artifact_not_matching_the_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_not_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_there_is_an_artifact_not_matching_the_topology.cs
@@ -19,11 +19,11 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_not_
         It should_generate_a_topology_with_features = () => topology.Features.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_modules = () => topology.Modules.ShouldBeEmpty();
         It should_generate_a_topology_with_two_top_level_features = () => topology.Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_with_module_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_with_module_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,8 +13,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_without_module_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_artifacts_without_module_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,11 +13,11 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module, ModuleDefinition>(),
+                new Dictionary<Feature, FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);
-        
+
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts_with_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts_with_module.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,8 +13,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts_without_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/given/a_configuration_without_topology_with_valid_artifacts_without_module.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 
 namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_using_modules.for_when_no_namespace_segments_to_strip.given
@@ -12,8 +13,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);        

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_all_artifacts_are_with_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_no_namespace_segments_to_strip/when_building_topology_when_all_artifacts_are_with_module.cs
@@ -20,12 +20,12 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
         It should_generate_a_topology_with_modules = () => topology.Modules.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_features = () => topology.Features.ShouldBeEmpty();
         It should_generate_a_topology_with_one_module = () => topology.Modules.Count().ShouldEqual(1);
-        It should_generate_a_topology_with_two_top_level_features = () => topology.Modules.First().Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Modules.First().Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_generate_a_topology_with_two_top_level_features = () => topology.Modules.First().Value.Features.Count().ShouldEqual(2);
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Modules.First().Value.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_with_module_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_with_module_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_without_module_where_one_artifact_does_not_match_topology.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_artifacts_without_module_where_one_artifact_does_not_match_topology.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts_with_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts_with_module.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts_without_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/given/a_configuration_without_topology_with_valid_artifacts_without_module.cs
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -13,8 +14,8 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
     {
         protected static readonly BoundedContextTopology configuration = new BoundedContextTopology(
             new Applications.Configuration.Topology(
-                new ModuleDefinition[0],
-                new FeatureDefinition[0]
+                new Dictionary<Module,ModuleDefinition>(),
+                new Dictionary<Feature,FeatureDefinition>()
             ), true, new Dictionary<Area, IEnumerable<string>>());
 
         protected static readonly TopologyBuilder topology_builder = new TopologyBuilder(artifacts, configuration, logger);

--- a/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_all_artifacts_are_with_module.cs
+++ b/Specifications/Build/for_Topology/for_TopologyBuilder/for_when_using_modules/for_when_stripping_one_namespace_segment/when_building_topology_when_all_artifacts_are_with_module.cs
@@ -20,13 +20,13 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyBuilder.for_when_usin
         It should_generate_a_topology_with_modules = () => topology.Modules.ShouldNotBeEmpty();
         It should_generate_a_topology_with_no_features = () => topology.Features.ShouldBeEmpty();
         It should_generate_a_topology_with_one_module = () => topology.Modules.Count().ShouldEqual(1);
-        It should_generate_a_topology_with_two_top_level_features = () => topology.Modules.First().Features.Count().ShouldEqual(2);
-        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature3").ShouldNotBeNull();
-        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Modules.First().Features.Single(_ => _.SubFeatures.Count() > 0).ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Count().ShouldEqual(1);
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").ShouldNotBeNull();
-        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Modules.First().Features.Single(_ => _.Name == (FeatureName)"Feature").SubFeatures.Single(_ => _.Name == (FeatureName)"Feature2").SubFeatures.ShouldBeEmpty();
+        It should_generate_a_topology_with_two_top_level_features = () => topology.Modules.First().Value.Features.Count().ShouldEqual(2);
+        It should_have_a_single_top_level_feature_where_name_is_Feature = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_where_name_is_Feature3 = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature3").ShouldNotBeNull();
+        It should_have_a_single_top_level_feature_that_has_sub_features = () => topology.Modules.First().Value.Features.Single(_ => _.Value.SubFeatures.Count() > 0).ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Count().ShouldEqual(1);
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3 = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").ShouldNotBeNull();
+        It should_have_a_single_feature_with_name_Feature_that_has_a_single_sub_feature_with_name_Feature3_that_has_no_sub_features = () => topology.Modules.First().Value.Features.Single(_ => _.Value.Name == (FeatureName)"Feature").Value.SubFeatures.Single(_ => _.Value.Name == (FeatureName)"Feature2").Value.SubFeatures.ShouldBeEmpty();
         
     }
 }

--- a/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_not_using_modules/when_validating_topology_with_a_feature_with_a_feature.cs
+++ b/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_not_using_modules/when_validating_topology_with_a_feature_with_a_feature.cs
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -17,9 +19,16 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyConfigurationExtensio
 
         Establish context = () => 
         {
-            var feature_def_2 = new FeatureDefinition(){Feature = Guid.NewGuid(), Name = "Feature2"};
-            var feature_def_1 = new FeatureDefinition(){Feature = Guid.NewGuid(), Name = "Feature1", SubFeatures = new []{feature_def_2}};
-            topology = new Applications.Configuration.Topology(new ModuleDefinition[0],new[]{feature_def_1});
+            var feature_def_2 = new FeatureDefinition("Feature2", new Dictionary<Feature,FeatureDefinition>());
+            var feature_def_1 = new FeatureDefinition("Feature1", new Dictionary<Feature, FeatureDefinition>
+            {
+                {Guid.NewGuid(), feature_def_2}
+            });
+
+            topology = new Applications.Configuration.Topology(new Dictionary<Module,ModuleDefinition>(), new Dictionary<Feature, FeatureDefinition>
+            {
+                {Guid.NewGuid(), feature_def_1}
+            });
         };
 
         Because of = () => exception_result = Catch.Exception(() => topology.ValidateTopology(false, logger));

--- a/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_not_using_modules/when_validating_topology_with_a_feature_with_a_feature_with_duplicate_id.cs
+++ b/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_not_using_modules/when_validating_topology_with_a_feature_with_a_feature_with_duplicate_id.cs
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -17,10 +19,16 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyConfigurationExtensio
         Establish context = () => 
         {
             var feature_id = Guid.NewGuid();
-            var feature_def_2 = new FeatureDefinition(){Feature = feature_id, Name = "Feature2"};
-            var feature_def_1 = new FeatureDefinition(){Feature = feature_id, Name = "Feature1", SubFeatures = new []{feature_def_2}};
+            var feature_def_2 = new FeatureDefinition("Feature2", new Dictionary<Feature,FeatureDefinition>());
+            var feature_def_1 = new FeatureDefinition("Feature1", new Dictionary<Feature, FeatureDefinition>
+            {
+                {feature_id, feature_def_2}
+            });
 
-            topology = new Applications.Configuration.Topology(new ModuleDefinition[0], new[]{feature_def_1});
+            topology = new Applications.Configuration.Topology(new Dictionary<Module,ModuleDefinition>(), new Dictionary<Feature, FeatureDefinition>
+            {
+                {feature_id, feature_def_1}
+            });
         };
         Because of = () => exception_result = Catch.Exception(() => topology.ValidateTopology(false, logger));
 

--- a/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_using_modules/when_validating_topology_with_a_module_with_a_feature.cs
+++ b/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_using_modules/when_validating_topology_with_a_module_with_a_feature.cs
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -16,9 +18,15 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyConfigurationExtensio
 
         Establish context = () => 
         {
-            var feature = new FeatureDefinition(){Feature = Guid.NewGuid(), Name = "Module"};
-            var module = new ModuleDefinition(){Module = Guid.NewGuid(), Name = "Module", Features = new []{feature}};
-            topology = new Applications.Configuration.Topology(new[]{module}, new FeatureDefinition[0]);
+            var feature = new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>());
+            var module = new ModuleDefinition("Module", new Dictionary<Feature, FeatureDefinition>
+            {
+                {Guid.NewGuid(), feature}
+            });
+            topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>
+            {
+                {Guid.NewGuid(), module}
+            }, new Dictionary<Feature, FeatureDefinition>());
         };
 
 

--- a/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_using_modules/when_validating_topology_with_a_module_with_a_feature_with_duplicate_id.cs
+++ b/Specifications/Build/for_Topology/for_TopologyConfigurationExtensions/for_ValidateTopology/for_when_using_modules/when_validating_topology_with_a_module_with_a_feature_with_duplicate_id.cs
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System;
+using System.Collections.Generic;
+using Dolittle.Applications;
 using Dolittle.Applications.Configuration;
 using Machine.Specifications;
 
@@ -18,9 +20,15 @@ namespace Dolittle.Build.Topology.for_Topology.for_TopologyConfigurationExtensio
         Establish context = () => 
         {
             var id = Guid.NewGuid();
-            var feature = new FeatureDefinition(){Feature = id, Name = "Module"};
-            var module = new ModuleDefinition(){Module = id, Name = "Module", Features = new []{feature}};
-            topology = new Applications.Configuration.Topology(new[]{module}, new FeatureDefinition[0]);
+            var feature = new FeatureDefinition("Feature", new Dictionary<Feature, FeatureDefinition>());
+            var module = new ModuleDefinition("Module", new Dictionary<Feature, FeatureDefinition>
+            {
+                {id, feature}
+            });
+            topology = new Applications.Configuration.Topology(new Dictionary<Module, ModuleDefinition>
+            {
+                {id, module}
+            }, new Dictionary<Feature, FeatureDefinition>());
         };
 
         Because of = () => exception_result = Catch.Exception(() => topology.ValidateTopology(true, logger));


### PR DESCRIPTION
Related to 
https://github.com/dolittle/Home/issues/34

This removes the not needed key field of configuration objects and move it up one level. 
So instead of : 

```json
{
   "modules": [
       {
           "module": "<some id>",
           ".... configuration key..":"values..
       }
   ]
}
```

it becomes:

```json
{
   "modules": {
         "module id": {
           ".... configuration key..":"values..
       }
   }
}
```

