### PR TITLE
Fixing versions to be 2.*

### DIFF
--- a/Source/Commands.Security/Bindings.cs
+++ b/Source/Commands.Security/Bindings.cs
@@ -11,7 +11,7 @@ namespace Dolittle.Commands.Security
     /// <summary>
     /// Bindings required for Commands.Security
     /// </summary>
-    public class SecurityDescriptorBindings : ICanProvideBindings
+    public class Bindings : ICanProvideBindings
     {
         /// <inheritdoc />
         public void Provide(IBindingProviderBuilder builder)

--- a/Source/Commands.Security/Commands.Security.csproj
+++ b/Source/Commands.Security/Commands.Security.csproj
@@ -6,9 +6,9 @@
         <AssemblyName>Dolittle.SDK.Commands.Security</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dolittle.DependencyInversion" Version="2.0.2" />
-        <PackageReference Include="Dolittle.Runtime.Commands.Security" Version="2.0.2" />
-        <PackageReference Include="Dolittle.Runtime.Commands" Version="2.0.2" />
+        <PackageReference Include="Dolittle.DependencyInversion" Version="2.*" />
+        <PackageReference Include="Dolittle.Runtime.Commands.Security" Version="2.*" />
+        <PackageReference Include="Dolittle.Runtime.Commands" Version="2.*" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Commands.Handling\Commands.Handling.csproj" />


### PR DESCRIPTION
When we have the separation complete between SDK and Runtime, we might consider locking more on versions. With 2.* we get anything 2 and we should force ourselves to be careful about the versioning. 