### PR TITLE
Don't let errors in Event Processors bubble out of UncommittedEventStreamCoordinator

### DIFF
--- a/Specifications/Commands/Commands.csproj
+++ b/Specifications/Commands/Commands.csproj
@@ -2,7 +2,7 @@
     <Import Project="../../Build/MSBuild/specs.props"/>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <AssemblyName>Dolittle.SDK.Commands.Specs</AssemblyName>
     </PropertyGroup>
 


### PR DESCRIPTION
Just logging the errors for now.  I guess we need some kind of reporting system for the state of event processors.