### PR TITLE
DL1002 rule - EventsMustHaveMatchingConstructorArguments

### DIFF
--- a/Source/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/Analyzer.cs
+++ b/Source/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/Analyzer.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Dolittle.SDK.CodeAnalysis.EventsMustHaveMatchingConstructorArguments
+{
+    /// <summary>
+    /// Represents a <see cref="DiagnosticAnalyzer"/> that does not allow the use of 'private' keyword.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class Analyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
+        /// </summary>
+        public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+             id: "DL1002",
+             title: "EventsMustHaveMatchingConstructorArguments",
+             messageFormat: "Events must have matching constructor arguments. Property '{0}' does not have a matching constructor parameter '{1}'",
+             category: "Events",
+             defaultSeverity: DiagnosticSeverity.Error,
+             isEnabledByDefault: true,
+             description: null,
+             helpLinkUri: $"",
+             customTags: Array.Empty<string>());
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(
+                HandlePropertyDeclaration,
+                ImmutableArray.Create(SyntaxKind.PropertyDeclaration));
+        }
+
+        void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var owningClass = context.Node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (owningClass != default && owningClass.ImplementsInterface("Dolittle.Events", "IEvent", context.SemanticModel))
+            {
+                var property = context.Node as PropertyDeclarationSyntax;
+                var constructor = owningClass.Members.OfType<ConstructorDeclarationSyntax>().FirstOrDefault();
+                var propertyName = property.Identifier.ValueText;
+                var constructorArguments = constructor != default ? constructor.ParameterList.Parameters.Select(_ => _.Identifier.ValueText) : Array.Empty<string>();
+                if (!constructorArguments.Any(arg => AsPascalCase(arg).Equals(propertyName, StringComparison.InvariantCulture)))
+                {
+                    var diagnostic = Diagnostic.Create(Rule, property.GetLocation(), propertyName, AsCamelCase(propertyName));
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        string AsPascalCase(string str) => str[0].ToString(CultureInfo.InvariantCulture).ToUpperInvariant() + str.Substring(1);
+
+#pragma warning disable CA1308
+        string AsCamelCase(string str) => str[0].ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture) + str.Substring(1);
+    }
+}

--- a/Specifications/CodeAnalysis/CodeAnalysis.csproj
+++ b/Specifications/CodeAnalysis/CodeAnalysis.csproj
@@ -11,6 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Dolittle.Runtime.Events" Version="4.*" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/Specifications/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/UnitTests.cs
+++ b/Specifications/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/UnitTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Events;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Dolittle.SDK.CodeAnalysis.EventsMustHaveMatchingConstructorArguments
+{
+    [TestClass]
+    public class UnitTests : CodeFixVerifier
+    {
+        [TestMethod]
+        public void EventWithoutProperties()
+        {
+            const string content = @"
+                using Dolittle.Events;
+
+                namespace MyNamespace
+                {
+                    public class MyEvent : IEvent
+                    {
+                    }
+                }
+            ";
+
+            VerifyCSharpDiagnostic(content);
+        }
+
+        [TestMethod]
+        public void EventWithMatchingConstructorArguments()
+        {
+            const string content = @"
+                using Dolittle.Events;
+
+                namespace MyNamespace
+                {
+                    public class MyEvent : IEvent
+                    {
+                        public MyEvent(int first, string second)
+                        {
+                            First = first;
+                            Second = second;
+                        }
+
+                        public int First { get; }
+
+                        public string Second { get; }
+                    }
+                }
+            ";
+
+            VerifyCSharpDiagnostic(content);
+        }
+
+        [TestMethod]
+        public void EventWithAPropertyAndNoConstructorArguments()
+        {
+            const string content = @"
+                using Dolittle.Events;
+
+                namespace MyNamespace
+                {
+                    public class MyEvent : IEvent
+                    {
+                        public int First { get; }
+                    }
+                }
+            ";
+
+            var firstProperty = new DiagnosticResult
+            {
+                Id = Analyzer.Rule.Id,
+                Message = string.Format(null, Analyzer.Rule.MessageFormat.ToString(), "First", "first"),
+                Severity = Analyzer.Rule.DefaultSeverity,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 8, 25)
+                }
+            };
+
+            VerifyCSharpDiagnostic(content, firstProperty);
+        }
+
+        [TestMethod]
+        public void EventWithTooFewConstructorArguments()
+        {
+            const string content = @"
+                using Dolittle.Events;
+
+                namespace MyNamespace
+                {
+                    public class MyEvent : IEvent
+                    {
+                        public MyEvent(int first)
+                        {
+                            First = first;
+                            Second = \""something\"";
+                        }
+
+                        public int First { get; }
+
+                        public string Second { get; }
+                    }
+                }
+            ";
+            var secondProperty = new DiagnosticResult
+            {
+                Id = Analyzer.Rule.Id,
+                Message = string.Format(null, Analyzer.Rule.MessageFormat.ToString(), "Second", "second"),
+                Severity = Analyzer.Rule.DefaultSeverity,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 16, 25)
+                }
+            };
+            VerifyCSharpDiagnostic(content, secondProperty);
+        }
+
+        [TestMethod]
+        public void EventWithMisMatchingConstructorArguments()
+        {
+            const string content = @"
+                using Dolittle.Events;
+
+                namespace MyNamespace
+                {
+                    public class MyEvent : IEvent
+                    {
+                        public MyEvent(int firstSomething, string secondSomething)
+                        {
+                            First = firstSomething;
+                            Second = secondSomething;
+                        }
+
+                        public int First { get; }
+
+                        public string Second { get; }
+                    }
+                }
+            ";
+            var firstProperty = new DiagnosticResult
+            {
+                Id = Analyzer.Rule.Id,
+                Message = string.Format(null, Analyzer.Rule.MessageFormat.ToString(), "First", "first"),
+                Severity = Analyzer.Rule.DefaultSeverity,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 14, 25)
+                }
+            };
+
+            var secondProperty = new DiagnosticResult
+            {
+                Id = Analyzer.Rule.Id,
+                Message = string.Format(null, Analyzer.Rule.MessageFormat.ToString(), "Second", "second"),
+                Severity = Analyzer.Rule.DefaultSeverity,
+                Locations = new[]
+                {
+                    new DiagnosticResultLocation("Test0.cs", 16, 25)
+                }
+            };
+
+            // while (!System.Diagnostics.Debugger.IsAttached) System.Threading.Thread.Sleep(100);
+            VerifyCSharpDiagnostic(content, firstProperty, secondProperty);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new Analyzer();
+        }
+
+        protected override IEnumerable<string> AdditionalAssemblyReferences => new[] { typeof(IEvent).Assembly.FullName };
+    }
+}

--- a/Specifications/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/UnitTests.cs
+++ b/Specifications/CodeAnalysis/EventsMustHaveMatchingConstructorArguments/UnitTests.cs
@@ -119,7 +119,7 @@ namespace Dolittle.SDK.CodeAnalysis.EventsMustHaveMatchingConstructorArguments
         }
 
         [TestMethod]
-        public void EventWithMisMatchingConstructorArguments()
+        public void EventWithMismatchingConstructorArguments()
         {
             const string content = @"
                 using Dolittle.Events;

--- a/Specifications/CodeAnalysis/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Specifications/CodeAnalysis/Helpers/DiagnosticVerifier.Helper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -106,6 +105,7 @@ namespace Dolittle.SDK.CodeAnalysis
         #endregion
 
         #region Set up compilation and documents
+
         /// <summary>
         /// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
         /// </summary>

--- a/Specifications/CodeAnalysis/Verifiers/CodeFixVerifier.cs
+++ b/Specifications/CodeAnalysis/Verifiers/CodeFixVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/Specifications/CodeAnalysis/Verifiers/DiagnosticVerifier.cs
+++ b/Specifications/CodeAnalysis/Verifiers/DiagnosticVerifier.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1158903060442937)
