### PR TITLE
Ensure subscription to event horizon

### DIFF
--- a/Source/Commands.Handling/CommandHandlerInvoker.cs
+++ b/Source/Commands.Handling/CommandHandlerInvoker.cs
@@ -86,7 +86,7 @@ namespace Dolittle.Commands.Handling
         {
             EnsureInitialized();
 
-            _logger.Information($"Trying to invoke command handlers for {command.Type}");
+            _logger.Debug($"Trying to invoke command handlers for {command.Type}");
 
             if (_commandHandlers.Count == 0) return false;
 
@@ -113,7 +113,7 @@ namespace Dolittle.Commands.Handling
             }
             else
             {
-                _logger.Information("No command handlers to invoke");
+                _logger.Debug("No command handlers to invoke");
             }
 
             return false;

--- a/Source/Commands.Validation/CommandValidatorProvider.cs
+++ b/Source/Commands.Validation/CommandValidatorProvider.cs
@@ -82,7 +82,7 @@ namespace Dolittle.Commands.Validation
         /// <inheritdoc/>
         public ICommandBusinessValidator GetBusinessValidatorFor(Type commandType)
         {
-            _logger.Information($"Get business validator for : {commandType.AssemblyQualifiedName}");
+            _logger.Debug($"Get business validator for : {commandType.AssemblyQualifiedName}");
 
             if (!typeof(ICommand).GetTypeInfo().IsAssignableFrom(commandType))
                 return null;
@@ -93,7 +93,7 @@ namespace Dolittle.Commands.Validation
 
             if (registeredBusinessValidatorType != null)
             {
-                _logger.Information($"Validator for {commandType.AssemblyQualifiedName} found");
+                _logger.Trace($"Validator for {commandType.AssemblyQualifiedName} found");
                 var validator = _container.Get(registeredBusinessValidatorType) as ICommandBusinessValidator;
 
                 if (hasCrossCuttingValidators && validator is IEnumerable<IValidationRule> enumerable)
@@ -104,7 +104,7 @@ namespace Dolittle.Commands.Validation
                     {
                         enumerable.ForEach(rule =>
                         {
-                            _logger.Information($"Adding rule with ruleset '{rule.RuleSet}'");
+                            _logger.Trace($"Adding rule with ruleset '{rule.RuleSet}'");
                             addRuleMethod.Invoke(dynamicValidator, new[] { rule });
                         });
                     }
@@ -115,14 +115,14 @@ namespace Dolittle.Commands.Validation
                 return validator;
             }
 
-            _logger.Information($"Building dynamic validator for {commandType.AssemblyQualifiedName}");
+            _logger.Trace($"Building dynamic validator for {commandType.AssemblyQualifiedName}");
             return BuildDynamicallyDiscoveredBusinessValidator(commandType, typesAndDiscoveredValidators);
         }
 
         /// <inheritdoc/>
         public ICommandInputValidator GetInputValidatorFor(Type commandType)
         {
-            _logger.Information($"Get input validator for : {commandType.AssemblyQualifiedName}");
+            _logger.Debug($"Get input validator for : {commandType.AssemblyQualifiedName}");
 
             if (!typeof(ICommand).GetTypeInfo().IsAssignableFrom(commandType))
                 return null;
@@ -134,7 +134,7 @@ namespace Dolittle.Commands.Validation
 
             if (registeredInputValidatorType != null)
             {
-                _logger.Information($"Validator for {commandType.AssemblyQualifiedName} found");
+                _logger.Trace($"Validator for {commandType.AssemblyQualifiedName} found");
                 var validator = _container.Get(registeredInputValidatorType) as ICommandInputValidator;
                 if (hasCrossCuttingValidators && validator is IEnumerable<IValidationRule> enumerable)
                 {
@@ -144,7 +144,7 @@ namespace Dolittle.Commands.Validation
                     {
                         enumerable.ForEach(rule =>
                         {
-                            _logger.Information($"Adding rule with ruleset '{rule.RuleSet}'");
+                            _logger.Trace($"Adding rule with ruleset '{rule.RuleSet}'");
                             addRuleMethod.Invoke(dynamicValidator, new[] { rule });
                         });
                     }
@@ -155,7 +155,7 @@ namespace Dolittle.Commands.Validation
                 return validator;
             }
 
-            _logger.Information($"Building dynamic validator for {commandType.AssemblyQualifiedName}");
+            _logger.Trace($"Building dynamic validator for {commandType.AssemblyQualifiedName}");
             return BuildDynamicallyDiscoveredInputValidator(commandType, typesAndDiscoveredValidators);
         }
 
@@ -181,7 +181,7 @@ namespace Dolittle.Commands.Validation
 
         ICommandInputValidator BuildDynamicallyDiscoveredInputValidator(Type commandType, IDictionary<Type, IEnumerable<Type>> typeAndAssociatedValidatorTypes)
         {
-            _logger.Information($"Build dynamic input validator for {commandType.AssemblyQualifiedName}");
+            _logger.Trace($"Build dynamic input validator for {commandType.AssemblyQualifiedName}");
             Type[] typeArgs = { commandType };
             var closedValidatorType = typeof(ComposedCommandInputValidatorFor<>).MakeGenericType(typeArgs);
 
@@ -193,14 +193,14 @@ namespace Dolittle.Commands.Validation
                 {
                     propertyTypeAndValidatorInstances.Add(key, validatorTypes.Select(v =>
                     {
-                        _logger.Information($"Adding validator {v.AssemblyQualifiedName}");
+                        _logger.Trace($"Adding validator {v.AssemblyQualifiedName}");
                         var validator = _container.Get(v) as IValidator;
                         return validator;
                     }).ToArray());
                 }
             }
 
-            _logger.Information($"Create instance dynamic composed validator of type {closedValidatorType.AssemblyQualifiedName}");
+            _logger.Trace($"Create instance dynamic composed validator of type {closedValidatorType.AssemblyQualifiedName}");
             return Activator.CreateInstance(closedValidatorType, propertyTypeAndValidatorInstances) as ICommandInputValidator;
         }
 
@@ -256,7 +256,7 @@ namespace Dolittle.Commands.Validation
                 return;
             }
 
-            _logger.Information($"Registering input validator {typeToRegister.AssemblyQualifiedName} for {commandType.AssemblyQualifiedName}");
+            _logger.Trace($"Registering input validator {typeToRegister.AssemblyQualifiedName} for {commandType.AssemblyQualifiedName}");
 
             validatorRegistry.Add(commandType, typeToRegister);
         }
@@ -271,7 +271,7 @@ namespace Dolittle.Commands.Validation
                 return;
             }
 
-            _logger.Information($"Registering validator of type {typeToRegister.AssemblyQualifiedName} for validation of {validatedType.AssemblyQualifiedName}");
+            _logger.Trace($"Registering validator of type {typeToRegister.AssemblyQualifiedName} for validation of {validatedType.AssemblyQualifiedName}");
 
             if (validatorRegistry.ContainsKey(validatedType))
             {

--- a/Source/EventHorizon/EventHorizon.cs
+++ b/Source/EventHorizon/EventHorizon.cs
@@ -10,7 +10,7 @@ namespace Dolittle.EventHorizon
     /// <summary>
     /// Represents the configuration of an event horizon.
     /// </summary>
-    public class EventHorizonConfiguration
+    public class EventHorizon
     {
         /// <summary>
         /// Gets or sets the <see cref="ScopeId" />.

--- a/Source/EventHorizon/EventHorizonsConfiguration.cs
+++ b/Source/EventHorizon/EventHorizonsConfiguration.cs
@@ -13,7 +13,7 @@ namespace Dolittle.EventHorizon
     /// </summary>
     [Name(ConfigurationName)]
     public class EventHorizonsConfiguration :
-        ReadOnlyDictionary<TenantId, IReadOnlyList<EventHorizonConfiguration>>,
+        ReadOnlyDictionary<TenantId, IReadOnlyList<EventHorizon>>,
         IConfigurationObject
     {
         /// <summary>
@@ -24,8 +24,8 @@ namespace Dolittle.EventHorizon
         /// <summary>
         /// Initializes a new instance of the <see cref="EventHorizonsConfiguration"/> class.
         /// </summary>
-        /// <param name="configuration">Dictionary for <see cref="TenantId"/> with <see cref="IReadOnlyList{T}" /> of ><see cref="EventHorizonConfiguration"/>.</param>
-        public EventHorizonsConfiguration(IDictionary<TenantId, IReadOnlyList<EventHorizonConfiguration>> configuration)
+        /// <param name="configuration">Dictionary for <see cref="TenantId"/> with <see cref="IReadOnlyList{T}" /> of ><see cref="EventHorizon"/>.</param>
+        public EventHorizonsConfiguration(IDictionary<TenantId, IReadOnlyList<EventHorizon>> configuration)
             : base(configuration)
         {
         }

--- a/Source/EventHorizon/FailedToSubscribeToEventHorizon.cs
+++ b/Source/EventHorizon/FailedToSubscribeToEventHorizon.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Dolittle.Applications;
+using Dolittle.Events;
 using Dolittle.Tenancy;
 
 namespace Dolittle.EventHorizon
@@ -15,11 +16,14 @@ namespace Dolittle.EventHorizon
         /// <summary>
         /// Initializes a new instance of the <see cref="FailedToSubscribeToEventHorizon"/> class.
         /// </summary>
+        /// <param name="failureReason">The failure reason.</param>
         /// <param name="subscriber">The subscriber <see cref="TenantId" />.</param>
-        /// <param name="microservice">The <see cref="Microservice" /> to subscribe to.</param>
+        /// <param name="producerMicroservice">The <see cref="Microservice" /> to subscribe to.</param>
         /// <param name="producerTenant">The <see cref="TenantId" /> to subscribe to.</param>
-        public FailedToSubscribeToEventHorizon(TenantId subscriber, Microservice microservice, TenantId producerTenant)
-            : base($"Tenant '{subscriber}' could not subscribe to event horizon for tenant '{producerTenant}' on microservice '{microservice}'")
+        /// <param name="publicStream">The <see cref="StreamId" /> to subscribe to.</param>
+        /// <param name="partition">The <see cref="PartitionId" /> in the stream to subscribe to.</param>
+        public FailedToSubscribeToEventHorizon(string failureReason, TenantId subscriber, Microservice producerMicroservice, TenantId producerTenant, StreamId publicStream, PartitionId partition)
+            : base($"Tenant '{subscriber}' could not subscribe to partition '{partition}' in public stream '{publicStream}' for tenant '{producerTenant}' on microservice '{producerMicroservice}. Reason: {failureReason}'")
         {
         }
     }

--- a/Source/EventHorizon/HeadConnectionLifecycle.cs
+++ b/Source/EventHorizon/HeadConnectionLifecycle.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Heads;
 using Dolittle.Logging;
+using Dolittle.Resilience;
 
 namespace Dolittle.EventHorizon
 {
@@ -14,18 +16,26 @@ namespace Dolittle.EventHorizon
     public class HeadConnectionLifecycle : ITakePartInHeadConnectionLifecycle
     {
         readonly ISubscriptionsClient _subscriptionsClient;
+        readonly EventHorizonsConfiguration _eventHorizons;
+        readonly IAsyncPolicyFor<HeadConnectionLifecycle> _policy;
         readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HeadConnectionLifecycle"/> class.
         /// </summary>
         /// <param name="subscriptionsClient">The <see cref="ISubscriptionsClient" />.</param>
+        /// <param name="eventHorizons">The <see cref="EventHorizonsConfiguration" />.</param>
+        /// <param name="policy">The <see cref="IAsyncPolicyFor{T}" /> <see cref="HeadConnectionLifecycle" />.</param>
         /// <param name="logger">The <see cref="ILogger" />.</param>
         public HeadConnectionLifecycle(
             ISubscriptionsClient subscriptionsClient,
+            EventHorizonsConfiguration eventHorizons,
+            IAsyncPolicyFor<HeadConnectionLifecycle> policy,
             ILogger logger)
         {
             _logger = logger;
+            _eventHorizons = eventHorizons;
+            _policy = policy;
             _subscriptionsClient = subscriptionsClient;
         }
 
@@ -33,10 +43,17 @@ namespace Dolittle.EventHorizon
         public bool IsReady() => Artifacts.Configuration.BootProcedure.HasPerformed;
 
         /// <inheritdoc/>
-        public Task OnConnected(CancellationToken token = default)
+        public async Task OnConnected(CancellationToken token = default)
         {
-            _subscriptionsClient.Subscribe();
-            return Task.CompletedTask;
+            _logger.Debug($"Subscribing to event horizons based on '{EventHorizonsConfiguration.ConfigurationName}' configuration.");
+            var tasks = _eventHorizons.SelectMany(_ =>
+                {
+                    var consumerTenant = _.Key;
+                    var eventHorizons = _.Value;
+                    return eventHorizons.Select(eventHorizon => _policy.Execute((token) => _subscriptionsClient.Subscribe(consumerTenant, eventHorizon, token), token));
+                });
+            if (!tasks.Any()) return;
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }
 }

--- a/Source/EventHorizon/HeadConnectionLifecyclePolicy.cs
+++ b/Source/EventHorizon/HeadConnectionLifecyclePolicy.cs
@@ -31,7 +31,7 @@ namespace Dolittle.EventHorizon
         public Polly.IAsyncPolicy Define() =>
             Polly.Policy.Handle<Exception>(_ =>
                 {
-                    _logger.Warning($"Failed to subscribe to event horizon : {_.Message}");
+                    _logger.Warning($"Error while subscribing to event horizon : {_.Message}");
                     return true;
                 })
                 .WaitAndRetryForeverAsync(_ => TimeSpan.FromSeconds(5));

--- a/Source/EventHorizon/HeadConnectionLifecyclePolicy.cs
+++ b/Source/EventHorizon/HeadConnectionLifecyclePolicy.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Logging;
+using Dolittle.Resilience;
+using Polly;
+
+namespace Dolittle.EventHorizon
+{
+    /// <summary>
+    /// Defines the policy for subscribing runtime to an event horizon.
+    /// </summary>
+    public class HeadConnectionLifecyclePolicy : IDefineAsyncPolicyForType
+    {
+        readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HeadConnectionLifecyclePolicy"/> class.
+        /// </summary>
+        /// <param name="logger"><see cref="ILogger"/> for logging.</param>
+        public HeadConnectionLifecyclePolicy(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public Type Type { get; } = typeof(HeadConnectionLifecycle);
+
+        /// <inheritdoc/>
+        public Polly.IAsyncPolicy Define() =>
+            Polly.Policy.Handle<Exception>(_ =>
+                {
+                    _logger.Warning($"Failed to subscribe to event horizon : {_.Message}");
+                    return true;
+                })
+                .WaitAndRetryForeverAsync(_ => TimeSpan.FromSeconds(5));
+    }
+}

--- a/Source/EventHorizon/ISubscriptionsClient.cs
+++ b/Source/EventHorizon/ISubscriptionsClient.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Tenancy;
+
 namespace Dolittle.EventHorizon
 {
     /// <summary>
@@ -9,8 +13,12 @@ namespace Dolittle.EventHorizon
     public interface ISubscriptionsClient
     {
         /// <summary>
-        /// Subscribes based on configurations.
+        /// Notifies the runtime to subscribe to an event horizon.
         /// </summary>
-        void Subscribe();
+        /// <param name="consumerTenant">The consumer <see cref="TenantId" />.</param>
+        /// <param name="eventHorizon">The <see cref="EventHorizon" />.</param>
+        /// <param name="token">Optional. The <see cref="CancellationToken" />.</param>
+        /// <returns>The asynchronous operation.</returns>
+        Task Subscribe(TenantId consumerTenant, EventHorizon eventHorizon, CancellationToken token = default);
     }
 }

--- a/Source/EventHorizon/ISubscriptionsClient.cs
+++ b/Source/EventHorizon/ISubscriptionsClient.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Tenancy;
 
@@ -17,8 +16,7 @@ namespace Dolittle.EventHorizon
         /// </summary>
         /// <param name="consumerTenant">The consumer <see cref="TenantId" />.</param>
         /// <param name="eventHorizon">The <see cref="EventHorizon" />.</param>
-        /// <param name="token">Optional. The <see cref="CancellationToken" />.</param>
         /// <returns>The asynchronous operation.</returns>
-        Task Subscribe(TenantId consumerTenant, EventHorizon eventHorizon, CancellationToken token = default);
+        Task Subscribe(TenantId consumerTenant, EventHorizon eventHorizon);
     }
 }

--- a/Source/EventHorizon/SubscriptionsClient.cs
+++ b/Source/EventHorizon/SubscriptionsClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 extern alias contracts;
 
-using System.Threading;
 using System.Threading.Tasks;
 using contracts::Dolittle.Runtime.EventHorizon;
 using Dolittle.Applications;
@@ -53,7 +52,7 @@ namespace Dolittle.EventHorizon
         }
 
         /// <inheritdoc/>
-        public async Task Subscribe(TenantId consumerTenant, EventHorizon eventHorizon, CancellationToken token)
+        public async Task Subscribe(TenantId consumerTenant, EventHorizon eventHorizon)
         {
             _logger.Trace($"Tenant '{consumerTenant}' subscribing for scope '{eventHorizon.Scope}' to partition '{eventHorizon.Partition}' in stream '{eventHorizon.Stream}' for tenant '{eventHorizon.Tenant}' in microservice '{eventHorizon.Microservice}'");
             var request = new Subscription
@@ -68,7 +67,8 @@ namespace Dolittle.EventHorizon
                 _application,
                 _microservice,
                 consumerTenant);
-            var response = await _client.SubscribeAsync(request, cancellationToken: token);
+            var response = await _client.SubscribeAsync(request);
+            _logger.Debug($"Tenant '{consumerTenant}' {(response.Failure == null ? "successfully" : "unsuccessfully")} subscribed for scope '{eventHorizon.Scope}' to partition '{eventHorizon.Partition}' in stream '{eventHorizon.Stream}' for tenant '{eventHorizon.Tenant}' in microservice '{eventHorizon.Microservice}'");
             if (response.Failure != null)
             {
                 throw new FailedToSubscribeToEventHorizon(response.Failure.Reason, consumerTenant, eventHorizon.Microservice, eventHorizon.Tenant, eventHorizon.Stream, eventHorizon.Partition);

--- a/Source/Events.Handling/EventHandlersWaiter.cs
+++ b/Source/Events.Handling/EventHandlersWaiter.cs
@@ -74,7 +74,7 @@ namespace Dolittle.Events.Handling
                     Task.Delay(delay).Wait();
                     if (timeout-- == 0)
                     {
-                        _logger.Information($"Waiting for event handlers timed out");
+                        _logger.Trace($"Waiting for event handlers timed out");
                         break;
                     }
                 }

--- a/Source/Heads/HeadLifecycleManager.cs
+++ b/Source/Heads/HeadLifecycleManager.cs
@@ -61,7 +61,7 @@ namespace Dolittle.Heads
         /// <inheritdoc/>
         public void Start()
         {
-            _logger.Information($"Connect client '{_head.Id}'");
+            _logger.Debug($"Connecting client '{_head.Id}'");
             var headId = _head.Id.ToProtobuf();
             var headInfo = new HeadInfo
             {


### PR DESCRIPTION
Based off new event horizon subscription contract from PR https://github.com/dolittle-runtime/Contracts/pull/13
Also based off the runtime subscription service implementation from PR https://github.com/dolittle-runtime/Runtime/pull/366

Modifies the HeadLifecycle for EventHorizon so that it keeps trying to subscribe to the event horizons that Head is configured to subscribe to.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1169777521194753)
