### PR TITLE
Upgrade to new contracts

### DIFF
--- a/Source/EventHorizon/ConsentId.cs
+++ b/Source/EventHorizon/ConsentId.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.ApplicationModel;
+using Dolittle.Concepts;
+using Dolittle.Tenancy;
+
+namespace Dolittle.EventHorizon
+{
+    /// <summary>
+    /// Represents an identifier for a consent given to share events between two <see cref="TenantId">tenants</see> in two <see cref="Microservice">microservices</see>.
+    /// </summary>
+    public class ConsentId : ConceptAs<Guid>
+    {
+        /// <summary>
+        /// Convert a <see cref="Guid"/> to a <see cref="ConsentId"/>.
+        /// </summary>
+        /// <param name="consentId">The identifier of the consent.</param>
+        public static implicit operator ConsentId(Guid consentId) => new ConsentId { Value = consentId };
+    }
+}

--- a/Source/EventHorizon/SubscriptionBootProcedure.cs
+++ b/Source/EventHorizon/SubscriptionBootProcedure.cs
@@ -66,7 +66,7 @@ namespace Dolittle.EventHorizon
                     }
                     else
                     {
-                        _logger.Debug("Sucessfully subscribed to events from {Partition} in {Stream} of {ProducerTenant} in {Microservice} for {ConsumerTenant} into {Scope}", subscription.Partition, subscription.Stream, subscription.Tenant, subscription.Microservice, consumer, subscription.Scope);
+                        _logger.Debug("Sucessfully subscribed to events from {Partition} in {Stream} of {ProducerTenant} in {Microservice} for {ConsumerTenant} into {Scope} approved by {Consent}", subscription.Partition, subscription.Stream, subscription.Tenant, subscription.Microservice, consumer, subscription.Scope, response.Consent);
                     }
                 },
                 CancellationToken.None);

--- a/Source/EventHorizon/SubscriptionResponse.cs
+++ b/Source/EventHorizon/SubscriptionResponse.cs
@@ -14,9 +14,11 @@ namespace Dolittle.EventHorizon
         /// <summary>
         /// Initializes a new instance of the <see cref="SubscriptionResponse"/> class.
         /// </summary>
-        /// <param name="failure">The optional <see cref="Failure"/> that occured during the subscription request.</param>
-        public SubscriptionResponse(Contracts.Failure failure)
+        /// <param name="consentId">The optional <see cref="Contracts.Uuid"/> that represents the <see cref="ConsentId"/> for this subscription.</param>
+        /// <param name="failure">The optional <see cref="Contracts.Failure"/> that occured during the subscription request.</param>
+        public SubscriptionResponse(Contracts.Uuid consentId, Contracts.Failure failure)
         {
+            if (consentId != null) Consent = consentId.To<ConsentId>();
             if (failure != null) Failure = failure;
         }
 
@@ -24,6 +26,11 @@ namespace Dolittle.EventHorizon
         /// Gets a value indicating whether the subscription was successful or not.
         /// </summary>
         public bool Success => Failure == null;
+
+        /// <summary>
+        /// Gets the <see cref="ConsentId"/> that was given to allow this subscription.
+        /// </summary>
+        public ConsentId Consent { get; }
 
         /// <summary>
         /// Gets the subscription response failure.

--- a/Source/EventHorizon/Subscriptions.cs
+++ b/Source/EventHorizon/Subscriptions.cs
@@ -63,7 +63,7 @@ namespace Dolittle.EventHorizon
                     MicroserviceId = subscription.Microservice.ToProtobuf(),
                     ScopeId = subscription.Scope.ToProtobuf()
                 }, cancellationToken: cancellationToken);
-            return new SubscriptionResponse(response.Failure);
+            return new SubscriptionResponse(response.ConsentId, response.Failure);
         }
     }
 }

--- a/Source/Events.Filters/Internal/EventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterProcessor.cs
@@ -13,7 +13,7 @@ namespace Dolittle.Events.Filters.Internal
     /// <summary>
     /// An implementation of <see cref="AbstractFilterProcessor{TEventType, TClientMessage, TRegistrationRequest, TFilterResponse}"/> used for <see cref="ICanFilterEvents"/>.
     /// </summary>
-    public class EventFilterProcessor : AbstractFilterProcessor<IEvent, FiltersClientToRuntimeMessage, FiltersRegistrationRequest, FilterResponse>
+    public class EventFilterProcessor : AbstractFilterProcessor<IEvent, FilterClientToRuntimeMessage, FilterRegistrationRequest, FilterResponse>
     {
         readonly ScopeId _scope;
         readonly FiltersClient _client;
@@ -50,8 +50,8 @@ namespace Dolittle.Events.Filters.Internal
         protected override string Kind => "filter";
 
         /// <inheritdoc/>
-        protected override IReverseCallClient<FiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, FiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, FilterResponse> CreateClient()
-            => _reverseCallClients.GetFor<FiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, FiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, FilterResponse>(
+        protected override IReverseCallClient<FilterClientToRuntimeMessage, FilterRuntimeToClientMessage, FilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, FilterResponse> CreateClient()
+            => _reverseCallClients.GetFor<FilterClientToRuntimeMessage, FilterRuntimeToClientMessage, FilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, FilterResponse>(
                 () => _client.Connect(),
                 (message, arguments) => message.RegistrationRequest = arguments,
                 message => message.RegistrationResponse,
@@ -62,8 +62,8 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context);
 
         /// <inheritdoc/>
-        protected override FiltersRegistrationRequest GetRegisterArguments()
-            => new FiltersRegistrationRequest
+        protected override FilterRegistrationRequest GetRegisterArguments()
+            => new FilterRegistrationRequest
             {
                 FilterId = Identifier.ToProtobuf(),
                 ScopeId = _scope.ToProtobuf(),

--- a/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
@@ -13,7 +13,7 @@ namespace Dolittle.Events.Filters.Internal
     /// <summary>
     /// An implementation of <see cref="AbstractFilterProcessor{TEventType, TClientMessage, TRegistrationRequest, TFilterResponse}"/> used for <see cref="ICanFilterEventsWithPartition"/>.
     /// </summary>
-    public class EventFilterWithPartitionsProcessor : AbstractFilterProcessor<IEvent, PartitionedFiltersClientToRuntimeMessage, PartitionedFiltersRegistrationRequest, PartitionedFilterResponse>
+    public class EventFilterWithPartitionsProcessor : AbstractFilterProcessor<IEvent, PartitionedFilterClientToRuntimeMessage, PartitionedFilterRegistrationRequest, PartitionedFilterResponse>
     {
         readonly ScopeId _scope;
         readonly FiltersClient _client;
@@ -50,8 +50,8 @@ namespace Dolittle.Events.Filters.Internal
         protected override string Kind => "partitioned filter";
 
         /// <inheritdoc/>
-        protected override IReverseCallClient<PartitionedFiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, PartitionedFiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse> CreateClient()
-            => _reverseCallClients.GetFor<PartitionedFiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, PartitionedFiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse>(
+        protected override IReverseCallClient<PartitionedFilterClientToRuntimeMessage, FilterRuntimeToClientMessage, PartitionedFilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse> CreateClient()
+            => _reverseCallClients.GetFor<PartitionedFilterClientToRuntimeMessage, FilterRuntimeToClientMessage, PartitionedFilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse>(
                 () => _client.ConnectPartitioned(),
                 (message, arguments) => message.RegistrationRequest = arguments,
                 message => message.RegistrationResponse,
@@ -62,8 +62,8 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context);
 
         /// <inheritdoc/>
-        protected override PartitionedFiltersRegistrationRequest GetRegisterArguments()
-            => new PartitionedFiltersRegistrationRequest
+        protected override PartitionedFilterRegistrationRequest GetRegisterArguments()
+            => new PartitionedFilterRegistrationRequest
             {
                 FilterId = Identifier.ToProtobuf(),
                 ScopeId = _scope.ToProtobuf(),

--- a/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Events.Filters.Internal
     /// <summary>
     /// An implementation of <see cref="AbstractFilterProcessor{TEventType, TClientMessage, TRegistrationRequest, TFilterResponse}"/> used for <see cref="ICanFilterPublicEvents"/>.
     /// </summary>
-    public class PublicEventFilterProcessor : AbstractFilterProcessor<IPublicEvent, PublicFiltersClientToRuntimeMessage, PublicFiltersRegistrationRequest, PartitionedFilterResponse>
+    public class PublicEventFilterProcessor : AbstractFilterProcessor<IPublicEvent, PublicFilterClientToRuntimeMessage, PublicFilterRegistrationRequest, PartitionedFilterResponse>
     {
         readonly FiltersClient _client;
         readonly IReverseCallClients _reverseCallClients;
@@ -47,8 +47,8 @@ namespace Dolittle.Events.Filters.Internal
         protected override string Kind => "public filter";
 
         /// <inheritdoc/>
-        protected override IReverseCallClient<PublicFiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, PublicFiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse> CreateClient()
-            => _reverseCallClients.GetFor<PublicFiltersClientToRuntimeMessage, FilterRuntimeToClientMessage, PublicFiltersRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse>(
+        protected override IReverseCallClient<PublicFilterClientToRuntimeMessage, FilterRuntimeToClientMessage, PublicFilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse> CreateClient()
+            => _reverseCallClients.GetFor<PublicFilterClientToRuntimeMessage, FilterRuntimeToClientMessage, PublicFilterRegistrationRequest, FilterRegistrationResponse, FilterEventRequest, PartitionedFilterResponse>(
                 () => _client.ConnectPublic(),
                 (message, arguments) => message.RegistrationRequest = arguments,
                 message => message.RegistrationResponse,
@@ -59,8 +59,8 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context);
 
         /// <inheritdoc/>
-        protected override PublicFiltersRegistrationRequest GetRegisterArguments()
-            => new PublicFiltersRegistrationRequest
+        protected override PublicFilterRegistrationRequest GetRegisterArguments()
+            => new PublicFilterRegistrationRequest
             {
                 FilterId = Identifier.ToProtobuf(),
             };

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Events.Handling.Internal
     /// Implementation of <see cref="EventProcessor{TIdentifier, TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> for Event Handlers.
     /// </summary>
     /// <typeparam name="TEventType">The event type that the handler can handle.</typeparam>
-    public class EventHandlerProcessor<TEventType> : EventProcessor<EventHandlerId, EventHandlersClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlersRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse>
+    public class EventHandlerProcessor<TEventType> : EventProcessor<EventHandlerId, EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlerRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse>
         where TEventType : IEvent
     {
         readonly ScopeId _scope;
@@ -78,8 +78,8 @@ namespace Dolittle.Events.Handling.Internal
         protected override EventHandlerId Identifier { get; }
 
         /// <inheritdoc/>
-        protected override IReverseCallClient<EventHandlersClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlersRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse> CreateClient()
-            => _reverseCallClients.GetFor<EventHandlersClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlersRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse>(
+        protected override IReverseCallClient<EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlerRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse> CreateClient()
+            => _reverseCallClients.GetFor<EventHandlerClientToRuntimeMessage, EventHandlerRuntimeToClientMessage, EventHandlerRegistrationRequest, EventHandlerRegistrationResponse, HandleEventRequest, EventHandlerResponse>(
                 () => _client.Connect(),
                 (message, arguments) => message.RegistrationRequest = arguments,
                 message => message.RegistrationResponse,
@@ -101,9 +101,9 @@ namespace Dolittle.Events.Handling.Internal
             => response.Failure;
 
         /// <inheritdoc/>
-        protected override EventHandlersRegistrationRequest GetRegisterArguments()
+        protected override EventHandlerRegistrationRequest GetRegisterArguments()
         {
-            var request = new EventHandlersRegistrationRequest
+            var request = new EventHandlerRegistrationRequest
             {
                 EventHandlerId = Identifier.ToProtobuf(),
                 ScopeId = _scope.ToProtobuf(),


### PR DESCRIPTION
- Removed plural s in Contracts messages
- Added ConsentId, return it in the SubscriptionResponse and log it in the BootProcedure

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1176095688032403)
