### PR TITLE
Special event context for external events

### DIFF
--- a/Source/Events/CommittedEventExtension.cs
+++ b/Source/Events/CommittedEventExtension.cs
@@ -4,20 +4,43 @@
 namespace Dolittle.Events
 {
     /// <summary>
-    /// Extension methods for <see cref="CommittedEvent" />.
+    /// Extension methods for <see cref="CommittedEvent"/>.
     /// </summary>
     public static class CommittedEventExtension
     {
         /// <summary>
-        /// Derices the <see cref="EventContext" /> from the <see cref="CommittedEvent" />.
+        /// Derives the <see cref="EventContext"/> for a <see cref="CommittedEvent"/>.
         /// </summary>
-        /// <param name="committedEvent">The <see cref="CommittedEvent" />.</param>
-        /// <returns>The derived <see cref="EventContext" />.</returns>
-        public static EventContext DeriveContext(this CommittedEvent committedEvent) =>
-            new EventContext(
+        /// <param name="committedEvent">The <see cref="CommittedEvent"/>.</param>
+        /// <returns>The derived <see cref="EventContext"/>.</returns>
+        public static EventContext DeriveContext(this CommittedEvent committedEvent)
+        {
+            if (committedEvent is CommittedExternalEvent externalEvent)
+            {
+                return externalEvent.DeriveContext();
+            }
+            else
+            {
+                return new EventContext(
+                    committedEvent.EventLogSequenceNumber,
+                    committedEvent.EventSource,
+                    committedEvent.Occurred,
+                    committedEvent.ExecutionContext);
+            }
+        }
+
+        /// <summary>
+        /// Derives the <see cref="ExternalEventContext"/> for a <see cref="CommittedExternalEvent"/>.
+        /// </summary>
+        /// <param name="committedEvent">The <see cref="CommittedExternalEvent"/>.</param>
+        /// <returns>The derived <see cref="ExternalEventContext"/>.</returns>
+        public static ExternalEventContext DeriveContext(this CommittedExternalEvent committedEvent) =>
+            new ExternalEventContext(
                 committedEvent.EventLogSequenceNumber,
                 committedEvent.EventSource,
                 committedEvent.Occurred,
-                committedEvent.ExecutionContext);
+                committedEvent.ExecutionContext,
+                committedEvent.ExternalEventLogSequenceNumber,
+                committedEvent.Recieved);
     }
 }

--- a/Source/Events/CommittedExternalEvent.cs
+++ b/Source/Events/CommittedExternalEvent.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Execution;
+
+namespace Dolittle.Events
+{
+    /// <summary>
+    /// Represents an Event that was received over the Event Horizon from an external Microservice.
+    /// </summary>
+    public class CommittedExternalEvent : CommittedEvent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommittedExternalEvent"/> class.
+        /// </summary>
+        /// <param name="eventLogSequenceNumber">The event log sequence number of the Event.</param>
+        /// <param name="occurred">The <see cref="DateTimeOffset"/> when the Event was committed to the Event Store.</param>
+        /// <param name="eventSourceId">The <see cref="EventSourceId"/> of the Event.</param>
+        /// <param name="executionContext">The <see cref="ExecutionContext"/> in which the Event was committed.</param>
+        /// <param name="externalEventLogSequenceNumber">The event log sequence number of the Event in the event log of the external Microservice that committed the event.</param>
+        /// <param name="received">The <see cref="DateTimeOffset"/> when the Event was received over the Event Horizon.</param>
+        /// <param name="event">An instance of the Event that was committed to the Event Store.</param>
+        public CommittedExternalEvent(
+            EventLogSequenceNumber eventLogSequenceNumber,
+            DateTimeOffset occurred,
+            EventSourceId eventSourceId,
+            ExecutionContext executionContext,
+            EventLogSequenceNumber externalEventLogSequenceNumber,
+            DateTimeOffset received,
+            IEvent @event)
+            : base(eventLogSequenceNumber, occurred, eventSourceId, executionContext, @event)
+        {
+            ExternalEventLogSequenceNumber = externalEventLogSequenceNumber;
+            Recieved = received;
+        }
+
+        /// <summary>
+        /// Gets the event log sequence number of the Event in the event log of the external Microservice that committed the event.
+        /// </summary>
+        public EventLogSequenceNumber ExternalEventLogSequenceNumber { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DateTimeOffset"/> when the Event was received over the Event Horizon.
+        /// </summary>
+        public DateTimeOffset Recieved { get; }
+    }
+}

--- a/Source/Events/EventContext.cs
+++ b/Source/Events/EventContext.cs
@@ -7,7 +7,7 @@ using Dolittle.Execution;
 namespace Dolittle.Events
 {
     /// <summary>
-    /// Reoresents the context in which an event occured in.
+    /// Represents the context in which an event occured in.
     /// </summary>
     public class EventContext
     {
@@ -23,12 +23,35 @@ namespace Dolittle.Events
             EventSourceId eventSourceId,
             DateTimeOffset occurred,
             ExecutionContext executionContext)
+            : this(
+                sequenceNumber,
+                eventSourceId,
+                occurred,
+                executionContext,
+                new EventIdentifier(executionContext.Microservice, executionContext.Tenant, sequenceNumber))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventContext"/> class.
+        /// </summary>
+        /// <param name="sequenceNumber">The <see cref="EventLogSequenceNumber">sequence number</see> that uniquely identifies the event in the event log which it was committed.</param>
+        /// <param name="eventSourceId">The <see cref="EventSourceId"/> that the event was committed to.</param>
+        /// <param name="occurred">The <see cref="DateTimeOffset"/> when the event was committed to the <see cref="IEventStore"/>.</param>
+        /// <param name="executionContext">The <see cref="ExecutionContext"/> in which the event was committed to the <see cref="IEventStore"/>.</param>
+        /// <param name="uniqueIdentifier">The <see cref="EventIdentifier"/> that uniquely identifies the event.</param>
+        protected EventContext(
+            EventLogSequenceNumber sequenceNumber,
+            EventSourceId eventSourceId,
+            DateTimeOffset occurred,
+            ExecutionContext executionContext,
+            EventIdentifier uniqueIdentifier)
         {
             SequenceNumber = sequenceNumber;
             EventSourceId = eventSourceId;
             Occurred = occurred;
             ExecutionContext = executionContext;
-            UniqueIdentifier = new EventIdentifier(ExecutionContext.Microservice, ExecutionContext.Tenant, SequenceNumber);
+            UniqueIdentifier = uniqueIdentifier;
         }
 
         /// <summary>

--- a/Source/Events/EventConverter.cs
+++ b/Source/Events/EventConverter.cs
@@ -75,12 +75,26 @@ namespace Dolittle.Events
         {
             var artifact = ToSDK(source.Type);
             var @event = _serializer.JsonToEvent(artifact, source.Content);
-            return new CommittedEvent(
-                source.EventLogSequenceNumber,
-                source.Occurred.ToDateTimeOffset(),
-                source.EventSourceId.To<EventSourceId>(),
-                source.ExecutionContext.ToExecutionContext(),
-                @event);
+            if (source.External)
+            {
+                return new CommittedExternalEvent(
+                    source.EventLogSequenceNumber,
+                    source.Occurred.ToDateTimeOffset(),
+                    source.EventSourceId.To<EventSourceId>(),
+                    source.ExecutionContext.ToExecutionContext(),
+                    source.ExternalEventLogSequenceNumber,
+                    source.ExternalEventReceived.ToDateTimeOffset(),
+                    @event);
+            }
+            else
+            {
+                return new CommittedEvent(
+                    source.EventLogSequenceNumber,
+                    source.Occurred.ToDateTimeOffset(),
+                    source.EventSourceId.To<EventSourceId>(),
+                    source.ExecutionContext.ToExecutionContext(),
+                    @event);
+            }
         }
 
         /// <inheritdoc/>

--- a/Source/Events/ExternalEventContext.cs
+++ b/Source/Events/ExternalEventContext.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Execution;
+
+namespace Dolittle.Events
+{
+    /// <summary>
+    /// Represents the context in which an external event occured in.
+    /// </summary>
+    public class ExternalEventContext : EventContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalEventContext"/> class.
+        /// </summary>
+        /// <param name="sequenceNumber">The <see cref="EventLogSequenceNumber">sequence number</see> that uniquely identifies the event in the event log which it was received.</param>
+        /// <param name="eventSourceId">The <see cref="EventSourceId"/> that the event was committed to.</param>
+        /// <param name="occurred">The <see cref="DateTimeOffset"/> when the event was committed to the <see cref="IEventStore"/>.</param>
+        /// <param name="executionContext">The <see cref="ExecutionContext"/> in which the event was committed to the <see cref="IEventStore"/>.</param>
+        /// <param name="externalEventLogSequenceNumber">The <see cref="EventLogSequenceNumber">sequence number</see> that uniquely identifies the event in the event log which it was committed (the external Microservice event log).</param>
+        /// <param name="received">The <see cref="DateTimeOffset"/> when the Event was received over the Event Horizon.</param>
+        public ExternalEventContext(
+            EventLogSequenceNumber sequenceNumber,
+            EventSourceId eventSourceId,
+            DateTimeOffset occurred,
+            ExecutionContext executionContext,
+            EventLogSequenceNumber externalEventLogSequenceNumber,
+            DateTimeOffset received)
+            : base(
+                sequenceNumber,
+                eventSourceId,
+                occurred,
+                executionContext,
+                new EventIdentifier(executionContext.Microservice, executionContext.Tenant, externalEventLogSequenceNumber))
+        {
+            ExternalEventLogSequenceNumber = externalEventLogSequenceNumber;
+            Recieved = received;
+        }
+
+        /// <summary>
+        /// Gets the event log sequence number of the Event in the event log of the external Microservice that committed the event.
+        /// </summary>
+        public EventLogSequenceNumber ExternalEventLogSequenceNumber { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DateTimeOffset"/> when the Event was received over the Event Horizon.
+        /// </summary>
+        public DateTimeOffset Recieved { get; }
+    }
+}

--- a/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_committed_event.cs
+++ b/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_committed_event.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+using given = Dolittle.Events.given;
+
+namespace Dolittle.Events.for_CommittedEventExtensions
+{
+    public class when_deriving_context_from_committed_event : given::Events
+    {
+        static CommittedEvent committed_event;
+        static EventLogSequenceNumber sequence_number;
+        static DateTimeOffset occurred;
+        static EventSourceId event_source;
+        static EventContext result;
+
+        Establish context = () =>
+        {
+            sequence_number = 1729;
+            occurred = DateTimeOffset.Now.AddMonths(-1);
+            event_source = Guid.Parse("e5bd8861-1821-4658-8a72-71bf97469ea9");
+            committed_event = new CommittedEvent(sequence_number, occurred, event_source, execution_context, event_one);
+        };
+
+        Because of = () => result = committed_event.DeriveContext();
+
+        It should_be_an_event_context = () => result.ShouldBeOfExactType<EventContext>();
+        It should_have_the_correct_sequence_number = () => result.SequenceNumber.ShouldEqual(sequence_number);
+        It should_have_the_correct_event_source = () => result.EventSourceId.ShouldEqual(event_source);
+        It should_have_the_correct_timestamp = () => result.Occurred.ShouldEqual(occurred);
+        It should_have_the_correct_execution_context = () => result.ExecutionContext.ShouldEqual(execution_context);
+        It should_have_the_correct_unique_identifier = () => result.UniqueIdentifier.Value.ShouldEqual("FvBR8iLWpE2bH34HjMicgGmkF77U7Q1LvCsgbQteafDBBgAAAAAAAA==");
+    }
+}

--- a/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_committed_external_event.cs
+++ b/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_committed_external_event.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+using given = Dolittle.Events.given;
+
+namespace Dolittle.Events.for_CommittedEventExtensions
+{
+    public class when_deriving_context_from_committed_external_event : given::Events
+    {
+        static CommittedEvent committed_event;
+        static EventLogSequenceNumber sequence_number;
+        static DateTimeOffset occurred;
+        static EventSourceId event_source;
+        static EventLogSequenceNumber external_sequence_number;
+        static DateTimeOffset received;
+        static EventContext result;
+
+        Establish context = () =>
+        {
+            sequence_number = 1729;
+            occurred = DateTimeOffset.Now.AddMonths(-1);
+            event_source = Guid.Parse("e5bd8861-1821-4658-8a72-71bf97469ea9");
+            external_sequence_number = 8128;
+            received = DateTimeOffset.Now.AddDays(-1);
+            committed_event = new CommittedExternalEvent(sequence_number, occurred, event_source, execution_context, external_sequence_number, received, event_one);
+        };
+
+        Because of = () => result = committed_event.DeriveContext();
+
+        It should_be_an_event_context = () => result.ShouldBeOfExactType<ExternalEventContext>();
+        It should_have_the_correct_sequence_number = () => result.SequenceNumber.ShouldEqual(sequence_number);
+        It should_have_the_correct_event_source = () => result.EventSourceId.ShouldEqual(event_source);
+        It should_have_the_correct_timestamp = () => result.Occurred.ShouldEqual(occurred);
+        It should_have_the_correct_execution_context = () => result.ExecutionContext.ShouldEqual(execution_context);
+        It should_have_the_correct_unique_identifier = () => result.UniqueIdentifier.Value.ShouldEqual("FvBR8iLWpE2bH34HjMicgGmkF77U7Q1LvCsgbQteafDAHwAAAAAAAA==");
+        It should_have_the_correct_external_sequence_number = () => (result as ExternalEventContext).ExternalEventLogSequenceNumber.ShouldEqual(external_sequence_number);
+        It should_have_the_correct_received_timestamp = () => (result as ExternalEventContext).Recieved.ShouldEqual(received);
+    }
+}

--- a/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_explicit_committed_external_event.cs
+++ b/Specifications/Events/for_CommittedEventExtensions/when_deriving_context_from_explicit_committed_external_event.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Machine.Specifications;
+using given = Dolittle.Events.given;
+
+namespace Dolittle.Events.for_CommittedEventExtensions
+{
+    public class when_deriving_context_from_explicit_committed_external_event : given::Events
+    {
+        static CommittedExternalEvent committed_event;
+        static EventLogSequenceNumber sequence_number;
+        static DateTimeOffset occurred;
+        static EventSourceId event_source;
+        static EventLogSequenceNumber external_sequence_number;
+        static DateTimeOffset received;
+        static ExternalEventContext result;
+
+        Establish context = () =>
+        {
+            sequence_number = 1729;
+            occurred = DateTimeOffset.Now.AddMonths(-12);
+            event_source = Guid.Parse("e5bd8861-1821-4658-8a72-71bf97469ea9");
+            external_sequence_number = 496;
+            received = DateTimeOffset.Now.AddDays(-7);
+            committed_event = new CommittedExternalEvent(sequence_number, occurred, event_source, execution_context, external_sequence_number, received, event_one);
+        };
+
+        Because of = () => result = committed_event.DeriveContext();
+
+        It should_have_the_correct_sequence_number = () => result.SequenceNumber.ShouldEqual(sequence_number);
+        It should_have_the_correct_event_source = () => result.EventSourceId.ShouldEqual(event_source);
+        It should_have_the_correct_timestamp = () => result.Occurred.ShouldEqual(occurred);
+        It should_have_the_correct_execution_context = () => result.ExecutionContext.ShouldEqual(execution_context);
+        It should_have_the_correct_unique_identifier = () => result.UniqueIdentifier.Value.ShouldEqual("FvBR8iLWpE2bH34HjMicgGmkF77U7Q1LvCsgbQteafDwAQAAAAAAAA==");
+        It should_have_the_correct_external_sequence_number = () => result.ExternalEventLogSequenceNumber.ShouldEqual(external_sequence_number);
+        It should_have_the_correct_received_timestamp = () => result.Recieved.ShouldEqual(received);
+    }
+}

--- a/Specifications/Events/for_EventConverter/when_converting_event_from_protobuf.cs
+++ b/Specifications/Events/for_EventConverter/when_converting_event_from_protobuf.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Artifacts;
+using Dolittle.Protobuf;
+using Dolittle.Serialization.Json;
+using Google.Protobuf.WellKnownTypes;
+using Machine.Specifications;
+using Moq;
+using given = Dolittle.Events.given;
+using grpcArtifacts = Dolittle.Artifacts.Contracts;
+using grpcEvents = Dolittle.Runtime.Events.Contracts;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Events.for_EventConverter
+{
+    public class when_converting_event_from_protobuf : given::Events
+    {
+        static Mock<IArtifactTypeMap> artifact_type_map;
+        static Mock<ISerializer> serializer;
+        static EventConverter converter;
+
+        static CommittedEvent result;
+        static grpcEvents.CommittedEvent input;
+
+        static Guid artifact;
+        static uint generation;
+        static MyEvent the_event;
+        static EventSourceId event_source;
+        static DateTimeOffset occurred;
+        static EventLogSequenceNumber event_log_sequence_number;
+
+        Establish context = () =>
+        {
+            artifact_type_map = new Mock<IArtifactTypeMap>();
+            serializer = new Mock<ISerializer>();
+
+            converter = new EventConverter(artifact_type_map.Object, serializer.Object);
+
+            artifact = Guid.Parse("0e5dce70-15f3-4e48-b0cc-ecb9dba50af4");
+            generation = 42;
+            the_event = new MyEvent();
+            event_source = Guid.Parse("c15f86b2-4cc2-40d0-88e4-c016916fdddf");
+            occurred = DateTimeOffset.UtcNow;
+            event_log_sequence_number = 5;
+
+            input = new grpcEvents.CommittedEvent
+            {
+                Type = new grpcArtifacts.Artifact
+                {
+                    Id = artifact.ToProtobuf(),
+                    Generation = generation
+                },
+                ExecutionContext = execution_context.ToProtobuf(),
+                EventSourceId = event_source.ToProtobuf(),
+                Occurred = Timestamp.FromDateTimeOffset(occurred),
+                EventLogSequenceNumber = event_log_sequence_number,
+                Content = "{\"someProperty\":42}",
+                Public = false,
+                External = false,
+            };
+
+            artifact_type_map.Setup(_ => _.GetTypeFor(new Artifact(artifact, generation))).Returns(typeof(MyEvent));
+            serializer.Setup(_ => _.FromJson(typeof(MyEvent), input.Content, SerializationOptions.CamelCase)).Returns(the_event);
+        };
+
+        Because of = () => result = converter.ToSDK(input);
+
+        It should_be_a_committed_event = () => result.ShouldBeOfExactType<CommittedEvent>();
+        It should_hold_the_event = () => result.Event.ShouldEqual(the_event);
+        It should_have_the_correct_timestamp = () => result.Occurred.ShouldEqual(occurred);
+        It should_have_the_correct_execution_context = () => result.ExecutionContext.ShouldEqual(execution_context);
+        It should_have_the_correct_event_source = () => result.EventSource.ShouldEqual(event_source);
+        It should_have_the_correct_event_log_sequence_number = () => result.EventLogSequenceNumber.ShouldEqual(event_log_sequence_number);
+    }
+}


### PR DESCRIPTION
- Introduced CommittedExternalEvent which represents events received over the EventHorizon.
- Introduced ExternalEventContext which corresponds to the context of a CommittedExternalEvent (like EventContext to CommittedEvent).
- Make EventConverter return CommittedExternalEvent when receiving committed events over gRPC with `External = true`.
- Make CommittedEventExtensions DeriveContext return ExternalEventContext when passed a CommittedExternalEvent.

We might consider changing the interface for ICanHandleExternalEvents so that the Handle methods also accept ExternalEventContext as the second parameter. So you don't have to check or cast the argument in code. But I'll leave that for a later PR.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1176137031450469)
