### PR TITLE
Fix eventual consistency bug: command returns before it's finished 

### DIFF
--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -120,8 +120,6 @@ namespace Dolittle.Events.Handling.Internal
                 });
             }
 
-            _completion.RegisterHandler(Identifier, _handler.HandledEventTypes);
-
             return request;
         }
 

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -120,6 +120,8 @@ namespace Dolittle.Events.Handling.Internal
                 });
             }
 
+            _completion.RegisterHandler(Identifier, _handler.HandledEventTypes);
+
             return request;
         }
 


### PR DESCRIPTION
`EventProcessingCompletion.RegisterHandler` was never called, meaning all the `EventHandlersWaiter.Complete()` would immediately return instead of waiting for the event handles as supposed to.

Still needs specs for it and the spot where the `RegisterHandler()` is called might not be the clearest one.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1178020984566255)
