### PR TITLE
Add ping

### DIFF
--- a/Source/Events.Filters/Internal/EventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterProcessor.cs
@@ -63,7 +63,7 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context,
                 message => message.Ping,
                 (message, pong) => message.Pong = pong,
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(5));
 
         /// <inheritdoc/>
         protected override FilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Filters/Internal/EventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 using Dolittle.Logging;
 using Dolittle.Protobuf;
@@ -59,7 +60,10 @@ namespace Dolittle.Events.Filters.Internal
                 (message, response) => message.FilterResult = response,
                 (arguments, context) => arguments.CallContext = context,
                 request => request.CallContext,
-                (response, context) => response.CallContext = context);
+                (response, context) => response.CallContext = context,
+                message => message.Ping,
+                (message, pong) => message.Pong = pong,
+                TimeSpan.FromSeconds(1));
 
         /// <inheritdoc/>
         protected override FilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 using Dolittle.Logging;
 using Dolittle.Protobuf;
@@ -59,7 +60,10 @@ namespace Dolittle.Events.Filters.Internal
                 (message, response) => message.FilterResult = response,
                 (arguments, context) => arguments.CallContext = context,
                 request => request.CallContext,
-                (response, context) => response.CallContext = context);
+                (response, context) => response.CallContext = context,
+                message => message.Ping,
+                (message, pong) => message.Pong = pong,
+                TimeSpan.FromSeconds(1));
 
         /// <inheritdoc/>
         protected override PartitionedFilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
+++ b/Source/Events.Filters/Internal/EventFilterWithPartitionsProcessor.cs
@@ -63,7 +63,7 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context,
                 message => message.Ping,
                 (message, pong) => message.Pong = pong,
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(5));
 
         /// <inheritdoc/>
         protected override PartitionedFilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
@@ -60,7 +60,7 @@ namespace Dolittle.Events.Filters.Internal
                 (response, context) => response.CallContext = context,
                 message => message.Ping,
                 (message, pong) => message.Pong = pong,
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(5));
 
         /// <inheritdoc/>
         protected override PublicFilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
+++ b/Source/Events.Filters/Internal/PublicEventFilterProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 using Dolittle.Events.Filters.EventHorizon;
 using Dolittle.Logging;
@@ -56,7 +57,10 @@ namespace Dolittle.Events.Filters.Internal
                 (message, response) => message.FilterResult = response,
                 (arguments, context) => arguments.CallContext = context,
                 request => request.CallContext,
-                (response, context) => response.CallContext = context);
+                (response, context) => response.CallContext = context,
+                message => message.Ping,
+                (message, pong) => message.Pong = pong,
+                TimeSpan.FromSeconds(1));
 
         /// <inheritdoc/>
         protected override PublicFilterRegistrationRequest GetRegisterArguments()

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -90,7 +90,7 @@ namespace Dolittle.Events.Handling.Internal
                 (response, context) => response.CallContext = context,
                 messsage => messsage.Ping,
                 (message, pong) => message.Pong = pong,
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(5));
 
         /// <inheritdoc/>
         protected override EventHandlerResponse CreateResponseFromFailure(ProcessorFailure failure)

--- a/Source/Events.Handling/Internal/EventHandlerProcessor.cs
+++ b/Source/Events.Handling/Internal/EventHandlerProcessor.cs
@@ -87,7 +87,10 @@ namespace Dolittle.Events.Handling.Internal
                 (message, response) => message.HandleResult = response,
                 (arguments, context) => arguments.CallContext = context,
                 request => request.CallContext,
-                (response, context) => response.CallContext = context);
+                (response, context) => response.CallContext = context,
+                messsage => messsage.Ping,
+                (message, pong) => message.Pong = pong,
+                TimeSpan.FromSeconds(1));
 
         /// <inheritdoc/>
         protected override EventHandlerResponse CreateResponseFromFailure(ProcessorFailure failure)


### PR DESCRIPTION
Depends on https://github.com/dolittle/DotNET.Fundamentals/pull/320
Makes it build again by adding missing arguments to the reverseCallClients.GetFor method calls.
Sets ping for event handlers and filters to be 1 second

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1181761739295739)
