### PR TITLE
Improve logging

### DIFF
--- a/Source/Commands.Handling/CommandHandlerInvoker.cs
+++ b/Source/Commands.Handling/CommandHandlerInvoker.cs
@@ -107,7 +107,7 @@ namespace Dolittle.Commands.Handling
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Failed invoking command handler {CommandHandlerType} for command of type {CommandType} with correlation {Correlation}", commandHandlerType.AssemblyQualifiedName, command.Type, command.CorrelationId);
+                    _logger.Warning(ex, "Failed invoking command handler {CommandHandlerType} for command of type {CommandType} with correlation {Correlation}", commandHandlerType.AssemblyQualifiedName, command.Type, command.CorrelationId);
                     return false;
                 }
 

--- a/Source/EventHorizon/SubscriptionBootProcedure.cs
+++ b/Source/EventHorizon/SubscriptionBootProcedure.cs
@@ -59,14 +59,36 @@ namespace Dolittle.EventHorizon
             => _policy.Execute(
                 async (cancellationToken) =>
                 {
+                    _logger.Trace(
+                            "Attempting to subscribe to events from {Partition} in {Stream} of {ProducerTenant} in {Microservice} for {ConsumerTenant} into {Scope}",
+                            subscription.Partition,
+                            subscription.Stream,
+                            subscription.Tenant,
+                            subscription.Microservice,
+                            consumer,
+                            subscription.Scope);
                     var response = await _subscriptions.Subscribe(consumer, subscription, cancellationToken).ConfigureAwait(false);
                     if (!response.Success)
                     {
-                        throw new FailedToSubscribeToEventHorizon(response.Failure.Reason, consumer, subscription.Microservice, subscription.Tenant, subscription.Stream, subscription.Partition);
+                        throw new FailedToSubscribeToEventHorizon(
+                            response.Failure.Reason,
+                            consumer,
+                            subscription.Microservice,
+                            subscription.Tenant,
+                            subscription.Stream,
+                            subscription.Partition);
                     }
                     else
                     {
-                        _logger.Debug("Sucessfully subscribed to events from {Partition} in {Stream} of {ProducerTenant} in {Microservice} for {ConsumerTenant} into {Scope} approved by {Consent}", subscription.Partition, subscription.Stream, subscription.Tenant, subscription.Microservice, consumer, subscription.Scope, response.Consent);
+                        _logger.Debug(
+                            "Successfully subscribed to events from {Partition} in {Stream} of {ProducerTenant} in {Microservice} for {ConsumerTenant} into {Scope} approved by {Consent}",
+                            subscription.Partition,
+                            subscription.Stream,
+                            subscription.Tenant,
+                            subscription.Microservice,
+                            consumer,
+                            subscription.Scope,
+                            response.Consent);
                     }
                 },
                 CancellationToken.None);

--- a/Source/EventHorizon/SubscriptionBootProcedurePolicy.cs
+++ b/Source/EventHorizon/SubscriptionBootProcedurePolicy.cs
@@ -36,6 +36,11 @@ namespace Dolittle.EventHorizon
                     {
                         if (_ is RpcException rpcException && rpcException.StatusCode == StatusCode.Unavailable)
                             return true;
+                        if (_ is FailedToSubscribeToEventHorizon)
+                        {
+                            _logger.Warning(_.Message);
+                            return true;
+                        }
 
                         _logger.Warning(_, "Error while subscribing to event horizon");
                         return true;

--- a/Source/Events.Processing/RegistrationFailed.cs
+++ b/Source/Events.Processing/RegistrationFailed.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Events.Processing
         /// <param name="id">The <see cref="ConceptAs{T}"/> of type <see cref="Guid"/> that identifies the event processor.</param>
         /// <param name="registerFailure">The <see cref="Failure"/> that occured.</param>
         public RegistrationFailed(string kind, ConceptAs<Guid> id, Failure registerFailure)
-            : base($"Failure occured during registration of {kind} {id}. {registerFailure.Reason}")
+            : base($"Failure occurred during registration of {kind} {id}. {registerFailure.Reason}")
         {
         }
     }


### PR DESCRIPTION
This repo is not yet configured with the automatic CI/CD through github actions

Added:
* Trace log for when attempting to subscribe to event horizon
* In event horizon subscription policy if Exception is FailedToSubscribeToEventHorizon only log the Exception message as the stack trace is just noise

Changed:
* Error => Warning log in CommandHandlerInvoker
* When registering EventProcessor put a delay of 1s. There was an edge case if the server was cancelling and it received a new connection request just before it shut down resulting in weird error messages. It is ok to wait here since there now is a scenario where the .Handle and .Connect calls on the ReverseCallClient just returns when it receives an RpcException with StatusCode == StatusCode.Cancelled

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1183328925316381)
